### PR TITLE
Remove Function::is_call

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -49,9 +49,8 @@ successors.
 
 Instructions are opaque to the allocator except for a few important
 bits: (1) `is_ret` (is a return instruction); (2) `is_branch` (is a
-branch instruction); (3) `is_call` (is a call instruction, for
-heuristic purposes only), (4) `is_move` (is a move between registers),
-and (5) a vector of Operands, covered below. Every block must end in a
+branch instruction); (3) `is_move` (is a move between registers), and
+(4) a vector of Operands, covered below. Every block must end in a
 return or branch.
 
 Both instructions and blocks are named by indices in contiguous index

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -15,7 +15,6 @@ use arbitrary::{Arbitrary, Unstructured};
 pub enum InstOpcode {
     Phi,
     Op,
-    Call,
     Ret,
     Branch,
 }
@@ -102,10 +101,6 @@ impl Function for Func {
 
     fn block_params(&self, block: Block) -> &[VReg] {
         &self.block_params[block.index()][..]
-    }
-
-    fn is_call(&self, insn: Inst) -> bool {
-        self.insts[insn.index()].op == InstOpcode::Call
     }
 
     fn is_ret(&self, insn: Inst) -> bool {
@@ -500,11 +495,10 @@ impl Func {
                         .all(|op| !builder.f.reftype_vregs.contains(&op.vreg()))
                     && bool::arbitrary(u)?;
 
-                let op = *u.choose(&[InstOpcode::Op, InstOpcode::Call])?;
                 builder.add_inst(
                     Block::new(block),
                     InstData {
-                        op,
+                        op: InstOpcode::Op,
                         operands,
                         clobbers,
                         is_safepoint,

--- a/src/ion/dump.rs
+++ b/src/ion/dump.rs
@@ -103,8 +103,6 @@ impl<'a, F: Function> Env<'a, F> {
                     .collect::<Vec<_>>();
                 let opname = if self.func.is_branch(inst) {
                     "br"
-                } else if self.func.is_call(inst) {
-                    "call"
                 } else if self.func.is_ret(inst) {
                     "ret"
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,10 +847,6 @@ pub trait Function {
     /// Get the block parameters for a given block.
     fn block_params(&self, block: Block) -> &[VReg];
 
-    /// Determine whether an instruction is a call instruction. This is used
-    /// only for splitting heuristics.
-    fn is_call(&self, insn: Inst) -> bool;
-
     /// Determine whether an instruction is a return instruction.
     fn is_ret(&self, insn: Inst) -> bool;
 


### PR DESCRIPTION
The documentation says that this is only used for heuristics, but it
is never actually called. This should be removed for now and perhaps
added back later if we find an actual use for it.