### PR TITLE
Add cargo-deny config.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "aarch64-linux-android" },
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+ignore = [
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+allow = [
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "MIT",
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+deny = []


### PR DESCRIPTION
This was excluded by mistake in #1; without a configuration, cargo-deny
runs with a default one, and rejects a lot of things (largely due to
open-source-but-not-allowlisted licenses).

This `deny.toml` comes from the regalloc.rs repo. It results in one
warning currently that will be resolved once #7 is.