### PR TITLE
Various fixes & minor improvements

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -589,7 +589,6 @@ pub fn machine_env() -> MachineEnv {
         [regs.iter().cloned().skip(24).collect(), vec![]];
     let scratch_by_class: [PReg; 2] = [PReg::new(31, RegClass::Int), PReg::new(0, RegClass::Float)];
     MachineEnv {
-        regs,
         preferred_regs_by_class,
         non_preferred_regs_by_class,
         scratch_by_class,

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -293,7 +293,6 @@ pub struct Env<'a, F: Function> {
     pub vreg_regs: Vec<VReg>,
     pub pregs: Vec<PRegData>,
     pub allocation_queue: PrioQueue,
-    pub clobbers: Vec<Inst>,   // Sorted list of insts with clobbers.
     pub safepoints: Vec<Inst>, // Sorted list of safepoint insts.
     pub safepoints_per_vreg: HashMap<usize, HashSet<Inst>>,
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -19,7 +19,7 @@ use crate::index::ContainerComparator;
 use crate::indexset::IndexSet;
 use crate::{
     define_index, Allocation, Block, Edit, Function, Inst, MachineEnv, Operand, PReg, ProgPoint,
-    RegClass, SpillSlot, VReg,
+    RegClass, VReg,
 };
 use smallvec::SmallVec;
 use std::cmp::Ordering;
@@ -336,7 +336,7 @@ pub struct Env<'a, F: Function> {
     pub allocs: Vec<Allocation>,
     pub inst_alloc_offsets: Vec<u32>,
     pub num_spillslots: u32,
-    pub safepoint_slots: Vec<(ProgPoint, SpillSlot)>,
+    pub safepoint_slots: Vec<(ProgPoint, Allocation)>,
 
     pub allocated_bundle_count: usize,
 

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -448,10 +448,6 @@ impl<'a, F: Function> Env<'a, F> {
             // For each instruction, in reverse order, process
             // operands and clobbers.
             for inst in insns.rev().iter() {
-                if self.func.inst_clobbers(inst).len() > 0 {
-                    self.clobbers.push(inst);
-                }
-
                 // Mark clobbers with CodeRanges on PRegs.
                 for i in 0..self.func.inst_clobbers(inst).len() {
                     // don't borrow `self`
@@ -1234,7 +1230,6 @@ impl<'a, F: Function> Env<'a, F> {
             }
         }
 
-        self.clobbers.sort_unstable();
         self.blockparam_ins.sort_unstable();
         self.blockparam_outs.sort_unstable();
         self.prog_move_srcs.sort_unstable_by_key(|(pos, _)| *pos);

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -105,8 +105,11 @@ impl<'a, F: Function> Env<'a, F> {
                 allocations: LiveRangeSet::new(),
             },
         );
-        for &preg in &self.env.regs {
-            self.pregs[preg.index()].reg = preg;
+        for i in 0..=PReg::MAX {
+            let preg_int = PReg::new(i, RegClass::Int);
+            self.pregs[preg_int.index()].reg = preg_int;
+            let preg_float = PReg::new(i, RegClass::Float);
+            self.pregs[preg_float.index()].reg = preg_float;
         }
         // Create VRegs from the vreg count.
         for idx in 0..self.func.num_vregs() {

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -62,7 +62,6 @@ impl<'a, F: Function> Env<'a, F> {
             vreg_regs: Vec::with_capacity(n),
             pregs: vec![],
             allocation_queue: PrioQueue::new(),
-            clobbers: vec![],
             safepoints: vec![],
             safepoints_per_vreg: HashMap::new(),
             spilled_bundles: vec![],

--- a/src/ion/stackmap.rs
+++ b/src/ion/stackmap.rs
@@ -58,10 +58,8 @@ impl<'a, F: Function> Env<'a, F> {
                     }
                     log::trace!("    -> covers safepoint {:?}", safepoints[safepoint_idx]);
 
-                    let slot = alloc
-                        .as_stack()
-                        .expect("Reference-typed value not in spillslot at safepoint");
-                    self.safepoint_slots.push((safepoints[safepoint_idx], slot));
+                    self.safepoint_slots
+                        .push((safepoints[safepoint_idx], alloc));
                     safepoint_idx += 1;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,12 +1139,6 @@ pub enum Edit {
 /// as well.
 #[derive(Clone, Debug)]
 pub struct MachineEnv {
-    /// Physical registers. Every register that might be mentioned in
-    /// any constraint must be listed here, even if it is not
-    /// allocatable (present in one of
-    /// `{preferred,non_preferred}_regs_by_class`).
-    pub regs: Vec<PReg>,
-
     /// Preferred physical registers for each class. These are the
     /// registers that will be allocated first, if free.
     pub preferred_regs_by_class: [Vec<PReg>; 2],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,13 +108,13 @@ impl PReg {
     /// all PRegs and index it efficiently.
     #[inline(always)]
     pub fn index(self) -> usize {
-        ((self.class as u8 as usize) << 5) | (self.hw_enc as usize)
+        ((self.class as u8 as usize) << Self::MAX_BITS) | (self.hw_enc as usize)
     }
 
     /// Construct a PReg from the value returned from `.index()`.
     #[inline(always)]
     pub fn from_index(index: usize) -> Self {
-        let class = (index >> 5) & 1;
+        let class = (index >> Self::MAX_BITS) & 1;
         let class = match class {
             0 => RegClass::Int,
             1 => RegClass::Float,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1180,8 +1180,11 @@ pub struct Output {
     /// Allocation offset in `allocs` for each instruction.
     pub inst_alloc_offsets: Vec<u32>,
 
-    /// Safepoint records: at a given program point, a reference-typed value lives in the given SpillSlot.
-    pub safepoint_slots: Vec<(ProgPoint, SpillSlot)>,
+    /// Safepoint records: at a given program point, a reference-typed value
+    /// lives in the given Allocation. Currently these are guaranteed to be
+    /// stack slots, but in the future an option may be added to allow
+    /// reftype value to be kept in registers at safepoints.
+    pub safepoint_slots: Vec<(ProgPoint, Allocation)>,
 
     /// Debug info: a labeled value (as applied to vregs by
     /// `Function::debug_value_labels()` on the input side) is located


### PR DESCRIPTION
- Fixed a bug from #13 with PRegs with index > 32
- Removed `regs` from `MachineEnv` since it's not actually needed.
- Return safepoint_slots as Allocations instead of SpillSlots .
  - This enables us to support reftype vregs in register locations in the
future.
-  Removed an unused `clobbers` vector.