### PR TITLE
Rework the API for outgoing blockparams

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -101,7 +101,7 @@ impl CFGInfo {
             }
             if require_no_branch_args {
                 let last = f.block_insns(block).last();
-                if f.branch_blockparam_arg_offset(block, last) > 0 {
+                if !f.inst_operands(last).is_empty() {
                     return Err(RegAllocError::DisallowedBranchArg(last));
                 }
             }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -315,6 +315,7 @@ impl<'a, F: Function> Env<'a, F> {
         while !workqueue.is_empty() {
             let block = workqueue.pop_front().unwrap();
             workqueue_set.remove(&block);
+            let insns = self.func.block_insns(block);
 
             log::trace!("computing liveins for block{}", block.index());
 
@@ -323,7 +324,16 @@ impl<'a, F: Function> Env<'a, F> {
             let mut live = self.liveouts[block.index()].clone();
             log::trace!(" -> initial liveout set: {:?}", live);
 
-            for inst in self.func.block_insns(block).rev().iter() {
+            // Include outgoing blockparams in the initial live set.
+            if self.func.is_branch(insns.last()) {
+                for i in 0..self.func.block_succs(block).len() {
+                    for param in self.func.branch_blockparams(block, insns.last(), i) {
+                        live.set(param.vreg(), true);
+                    }
+                }
+            }
+
+            for inst in insns.rev().iter() {
                 if let Some((src, dst)) = self.func.is_move(inst) {
                     live.set(dst.vreg().vreg(), false);
                     live.set(src.vreg().vreg(), true);
@@ -399,11 +409,32 @@ impl<'a, F: Function> Env<'a, F> {
 
         for i in (0..self.func.num_blocks()).rev() {
             let block = Block::new(i);
+            let insns = self.func.block_insns(block);
 
             self.stats.livein_blocks += 1;
 
             // Init our local live-in set.
             let mut live = self.liveouts[block.index()].clone();
+
+            // If the last instruction is a branch (rather than
+            // return), create blockparam_out entries.
+            if self.func.is_branch(insns.last()) {
+                for (i, &succ) in self.func.block_succs(block).iter().enumerate() {
+                    let blockparams_in = self.func.block_params(succ);
+                    let blockparams_out = self.func.branch_blockparams(block, insns.last(), i);
+                    for (&blockparam_in, &blockparam_out) in
+                        blockparams_in.iter().zip(blockparams_out)
+                    {
+                        let blockparam_out = VRegIndex::new(blockparam_out.vreg());
+                        let blockparam_in = VRegIndex::new(blockparam_in.vreg());
+                        self.blockparam_outs
+                            .push((blockparam_out, block, succ, blockparam_in));
+
+                        // Include outgoing blockparams in the initial live set.
+                        live.set(blockparam_out.index(), true);
+                    }
+                }
+            }
 
             // Initially, registers are assumed live for the whole block.
             for vreg in live.iter() {
@@ -424,25 +455,6 @@ impl<'a, F: Function> Env<'a, F> {
             for param in self.func.block_params(block) {
                 self.vreg_regs[param.vreg()] = *param;
                 self.vregs[param.vreg()].blockparam = block;
-            }
-
-            let insns = self.func.block_insns(block);
-
-            // If the last instruction is a branch (rather than
-            // return), create blockparam_out entries.
-            if self.func.is_branch(insns.last()) {
-                for (i, &succ) in self.func.block_succs(block).iter().enumerate() {
-                    let blockparams_in = self.func.block_params(succ);
-                    let blockparams_out = self.func.branch_blockparams(block, insns.last(), i);
-                    for (&blockparam_in, &blockparam_out) in
-                        blockparams_in.iter().zip(blockparams_out)
-                    {
-                        let blockparam_out = VRegIndex::new(blockparam_out.vreg());
-                        let blockparam_in = VRegIndex::new(blockparam_in.vreg());
-                        self.blockparam_outs
-                            .push((blockparam_out, block, succ, blockparam_in));
-                    }
-                }
             }
 
             // For each instruction, in reverse order, process
@@ -893,13 +905,6 @@ impl<'a, F: Function> Env<'a, F> {
                             (OperandKind::Def, OperandPos::Early) => ProgPoint::before(inst),
                             (OperandKind::Def, OperandPos::Late) => ProgPoint::after(inst),
                             (OperandKind::Use, OperandPos::Late) => ProgPoint::after(inst),
-                            // If this is a branch, extend `pos` to
-                            // the end of the block. (Branch uses are
-                            // blockparams and need to be live at the
-                            // end of the block.)
-                            (OperandKind::Use, _) if self.func.is_branch(inst) => {
-                                self.cfginfo.block_exit[block.index()]
-                            }
                             // If there are any reused inputs in this
                             // instruction, and this is *not* the
                             // reused input, force `pos` to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,21 +860,14 @@ pub trait Function {
     fn is_ret(&self, insn: Inst) -> bool;
 
     /// Determine whether an instruction is the end-of-block
-    /// branch. If so, its operands at the indices given by
-    /// `branch_blockparam_arg_offset()` below *must* be the block
-    /// parameters for each of its block's `block_succs` successor
-    /// blocks, in order.
+    /// branch.
     fn is_branch(&self, insn: Inst) -> bool;
 
     /// If `insn` is a branch at the end of `block`, returns the
-    /// operand index at which outgoing blockparam arguments are
-    /// found. Starting at this index, blockparam arguments for each
-    /// successor block's blockparams, in order, must be found.
-    ///
-    /// It is an error if `self.inst_operands(insn).len() -
-    /// self.branch_blockparam_arg_offset(insn)` is not exactly equal
-    /// to the sum of blockparam counts for all successor blocks.
-    fn branch_blockparam_arg_offset(&self, block: Block, insn: Inst) -> usize;
+    /// outgoing blockparam arguments for the given successor. The
+    /// number of arguments must match the number incoming blockparams
+    /// for each respective successor block.
+    fn branch_blockparams(&self, block: Block, insn: Inst, succ_idx: usize) -> &[VReg];
 
     /// Determine whether an instruction requires all reference-typed
     /// values to be placed onto the stack. For these instructions,

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -71,13 +71,12 @@ pub fn validate_ssa<F: Function>(f: &F, cfginfo: &CFGInfo) -> Result<(), RegAllo
                     return Err(RegAllocError::BB(block));
                 }
                 if f.is_branch(insn) {
-                    let expected = f
-                        .block_succs(block)
-                        .iter()
-                        .map(|&succ| f.block_params(succ).len())
-                        .sum();
-                    if f.inst_operands(insn).len() != expected {
-                        return Err(RegAllocError::Branch(insn));
+                    for (i, &succ) in f.block_succs(block).iter().enumerate() {
+                        let blockparams_in = f.block_params(succ);
+                        let blockparams_out = f.branch_blockparams(block, insn, i);
+                        if blockparams_in.len() != blockparams_out.len() {
+                            return Err(RegAllocError::Branch(insn));
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Branch parameters are not proper operands, so it doesn't make sense to represent them using `Operand`s. The constraint is irrelevant (you always want `Any`), and so is the position within the instruction (early/late).

This PR adds `Function::branch_params` which returns the branch parameters directly as a list of `VReg`s.

This is also useful for rematerialization (#8): branch parameters don't need to be in an actual register or stack slot if we can rematerialize them later. This would normally be required by the `Any` constraint used for branch parameters.