### PR TITLE
Fix fuzzbug related to bundle priority ordering.

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -78,7 +78,7 @@
 
 use crate::{
     Allocation, AllocationKind, Block, Edit, Function, Inst, InstPosition, Operand,
-    OperandConstraint, OperandKind, OperandPos, Output, PReg, ProgPoint, RegClass, VReg,
+    OperandConstraint, OperandKind, OperandPos, Output, PReg, ProgPoint, VReg,
 };
 
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -185,6 +185,11 @@ pub struct LiveBundle {
     pub spill_weight_and_props: u32,
 }
 
+pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 29) - 1;
+pub const MINIMAL_FIXED_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT;
+pub const MINIMAL_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 1;
+pub const BUNDLE_MAX_NORMAL_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 2;
+
 impl LiveBundle {
     #[inline(always)]
     pub fn set_cached_spill_weight_and_props(
@@ -194,7 +199,7 @@ impl LiveBundle {
         fixed: bool,
         stack: bool,
     ) {
-        debug_assert!(spill_weight < ((1 << 29) - 1));
+        debug_assert!(spill_weight <= BUNDLE_MAX_SPILL_WEIGHT);
         self.spill_weight_and_props = spill_weight
             | (if minimal { 1 << 31 } else { 0 })
             | (if fixed { 1 << 30 } else { 0 })


### PR DESCRIPTION
Changes in computation of bundle priorities during review of the initial
PR introduced a possible mis-ordering of priorities: inner-loop bundle
use weights could exceed the weights of 1_000_000 and 2_000_000 used for
minimal bundles without and with fixed uses (respectively). These two
kinds of minimal bundle are meant to be the highest-priority bundles,
evicting any other bundle they need to, because they can't be split
further. This PR introduces two special bundle weights for these two
kinds of bundles, and clamps all other bundle weights to just below
them.

Thanks to @Amanieu for reporting the issue! Fixes #19.