### PR TITLE
Support for debug-labels.

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -67,6 +67,7 @@ pub struct Func {
     block_params_out: Vec<Vec<Vec<VReg>>>,
     num_vregs: usize,
     reftype_vregs: Vec<VReg>,
+    debug_value_labels: Vec<(VReg, Inst, Inst, u32)>,
 }
 
 impl Function for Func {
@@ -119,6 +120,10 @@ impl Function for Func {
         &self.reftype_vregs[..]
     }
 
+    fn debug_value_labels(&self) -> &[(VReg, Inst, Inst, u32)] {
+        &self.debug_value_labels[..]
+    }
+
     fn is_move(&self, _: Inst) -> Option<(Operand, Operand)> {
         None
     }
@@ -164,6 +169,7 @@ impl FuncBuilder {
                 blocks: vec![],
                 num_vregs: 0,
                 reftype_vregs: vec![],
+                debug_value_labels: vec![],
             },
             insts_per_block: vec![],
         }
@@ -374,6 +380,21 @@ impl Func {
                 vregs.push(vreg);
                 if opts.reftypes && bool::arbitrary(u)? {
                     builder.f.reftype_vregs.push(vreg);
+                }
+                if bool::arbitrary(u)? {
+                    let assumed_end_inst = 10 * num_blocks;
+                    let mut start = u.int_in_range::<usize>(0..=assumed_end_inst)?;
+                    while start < assumed_end_inst {
+                        let end = u.int_in_range::<usize>(start..=assumed_end_inst)?;
+                        let label = u.int_in_range::<u32>(0..=100)?;
+                        builder.f.debug_value_labels.push((
+                            vreg,
+                            Inst::new(start),
+                            Inst::new(end),
+                            label,
+                        ));
+                        start = end;
+                    }
                 }
             }
             vregs_by_block.push(vregs.clone());

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -557,6 +557,8 @@ impl Func {
             }
         }
 
+        builder.f.debug_value_labels.sort_unstable();
+
         Ok(builder.finalize())
     }
 }

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -336,10 +336,6 @@ pub struct Env<'a, F: Function> {
     pub liveouts: Vec<IndexSet>,
     pub blockparam_outs: Vec<BlockparamOut>,
     pub blockparam_ins: Vec<BlockparamIn>,
-    /// Blockparam allocs: block, idx, vreg, alloc. Info to describe
-    /// blockparam locations at block entry, for metadata purposes
-    /// (e.g. for the checker).
-    pub blockparam_allocs: Vec<(Block, u32, VRegIndex, Allocation)>,
 
     pub ranges: Vec<LiveRange>,
     pub bundles: Vec<LiveBundle>,
@@ -390,6 +386,7 @@ pub struct Env<'a, F: Function> {
     pub inst_alloc_offsets: Vec<u32>,
     pub num_spillslots: u32,
     pub safepoint_slots: Vec<(ProgPoint, Allocation)>,
+    pub debug_locations: Vec<(u32, ProgPoint, ProgPoint, Allocation)>,
 
     pub allocated_bundle_count: usize,
 
@@ -595,7 +592,6 @@ pub struct Stats {
     pub spill_bundle_reg_success: usize,
     pub blockparam_ins_count: usize,
     pub blockparam_outs_count: usize,
-    pub blockparam_allocs_count: usize,
     pub halfmoves_count: usize,
     pub edits_count: usize,
 }

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -53,7 +53,6 @@ impl<'a, F: Function> Env<'a, F> {
             liveouts: Vec::with_capacity(func.num_blocks()),
             blockparam_outs: vec![],
             blockparam_ins: vec![],
-            blockparam_allocs: vec![],
             bundles: Vec::with_capacity(n),
             ranges: Vec::with_capacity(4 * n),
             spillsets: Vec::with_capacity(n),
@@ -81,6 +80,7 @@ impl<'a, F: Function> Env<'a, F> {
             inst_alloc_offsets: vec![],
             num_spillslots: 0,
             safepoint_slots: vec![],
+            debug_locations: vec![],
 
             stats: Stats::default(),
 
@@ -138,7 +138,7 @@ pub fn run<F: Function>(
         allocs: env.allocs,
         inst_alloc_offsets: env.inst_alloc_offsets,
         num_spillslots: env.num_spillslots as usize,
-        debug_locations: vec![],
+        debug_locations: env.debug_locations,
         safepoint_slots: env.safepoint_slots,
         stats: env.stats,
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -958,7 +958,14 @@ pub trait Function {
     /// match -- specifically, the returned metadata may cover only a
     /// subset of the requested ranges -- if the value is not live for
     /// the entire requested ranges.
-    fn debug_value_labels(&self) -> &[(Inst, Inst, VReg, u32)] {
+    ///
+    /// The instruction indices imply a program point just *before*
+    /// the instruction.
+    ///
+    /// Preconditions: we require this slice to be sorted in
+    /// lexicographic order (i.e., first by vreg, then by instruction
+    /// index), and we require the ranges to be non-overlapping.
+    fn debug_value_labels(&self) -> &[(VReg, Inst, Inst, u32)] {
         &[]
     }
 


### PR DESCRIPTION
If the client adds labels to vregs across ranges of instructions in the
input program, the regalloc will provide metadata in the `Output` that
describes the `Allocation`s in which each such vreg is stored for those
ranges. This allows the client to emit debug metadata telling a debugger
where to find program values at each point in the program.

This API surface had already been sketched, but no implementation
had existed (the returned debug-label info was always empty) prior
to this PR.

Developed as part of the regalloc2 integration in Cranelift. This is not
strictly needed by Cranelift -- currently it does a post-analysis to get
debug info -- but this will let us eliminate that post-analysis, and simplify
other aspects of the integration as well.

I've added debug-label generation to the fuzzer as well. The checker
doesn't validate that the labels correspond to reality, but (i) that would
be a fairly nontrivial change to the checker, (ii) the actual metadata
emission is fairly straightforward, and (iii) the only tricky property -- that
we're emitting metadata for ranges that are actually overlapping the
allocation we think they are -- is checked by a `debug_assert!`.