### PR TITLE
Allow pinned-vregs to be implicit liveins.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -977,6 +977,11 @@ pub trait Function {
     /// liverange computation will check that this is the case (that
     /// there are enough remaining allocatable pregs of every class to
     /// hold all Reg-constrained operands).
+    ///
+    /// Pinned vregs are implicitly live-in to the function: that is,
+    /// one can use a pinned vreg without having first defined it, and
+    /// this will take the value that that physical register (to which
+    /// the vreg is pinned) had at function entry.
     fn is_pinned_vreg(&self, _: VReg) -> Option<PReg> {
         None
     }


### PR DESCRIPTION
Previously, the regalloc required all liveins to be defined by a
pseudoinstruction at the start of the function body. The regalloc.rs
compatibility shim did this, but it's slightly inconvenient when using
the API directly. This change allows pinned vregs to be implicit liveins
to the function body instead.

Developed during Cranelift integration (bytecodealliance/wasmtime#3942).