### PR TITLE
Take vreg regclasses from the Function interface explicitly.

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -140,6 +140,10 @@ impl Function for Func {
         self.num_vregs
     }
 
+    fn vreg_regclass(&self, _: usize) -> RegClass {
+        RegClass::Int
+    }
+
     fn spillslot_size(&self, regclass: RegClass) -> usize {
         match regclass {
             RegClass::Int => 1,

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -14,7 +14,7 @@
 
 use super::{
     CodeRange, Env, InsertMovePrio, LiveBundle, LiveBundleIndex, LiveRange, LiveRangeFlag,
-    LiveRangeIndex, LiveRangeKey, LiveRangeListEntry, LiveRangeSet, PRegData, PRegIndex, RegClass,
+    LiveRangeIndex, LiveRangeKey, LiveRangeListEntry, LiveRangeSet, PRegData, PRegIndex,
     SpillSetIndex, Use, VRegData, VRegIndex, SLOT_NONE,
 };
 use crate::indexset::IndexSet;
@@ -112,7 +112,7 @@ impl<'a, F: Function> Env<'a, F> {
         // Create VRegs from the vreg count.
         for idx in 0..self.func.num_vregs() {
             // We'll fill in the real details when we see the def.
-            let reg = VReg::new(idx, RegClass::Int);
+            let reg = VReg::new(idx, self.func.vreg_regclass(idx));
             self.add_vreg(
                 reg,
                 VRegData {

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -283,6 +283,12 @@ impl<'a, F: Function> Env<'a, F> {
             let ssidx = SpillSetIndex::new(self.spillsets.len());
             let reg = self.vreg_regs[vreg.index()];
             let size = self.func.spillslot_size(reg.class()) as u8;
+            trace!(
+                "creating SpillSet for bundle {:?} vreg {:?} with class {:?}",
+                bundle,
+                reg,
+                reg.class(),
+            );
             self.spillsets.push(SpillSet {
                 vregs: smallvec![vreg],
                 slot: SpillSlotIndex::invalid(),

--- a/src/ion/spill.rs
+++ b/src/ion/spill.rs
@@ -27,6 +27,8 @@ impl<'a, F: Function> Env<'a, F> {
             let class = self.spillsets[self.bundles[bundle.index()].spillset.index()].class;
             let hint = self.spillsets[self.bundles[bundle.index()].spillset.index()].reg_hint;
 
+            trace!("bundle {:?} with class {:?} hint {:?}", bundle, class, hint);
+
             // This may be an empty-range bundle whose ranges are not
             // sorted; sort all range-lists again here.
             self.bundles[bundle.index()]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,6 +935,9 @@ pub trait Function {
     /// Get the number of `VReg` in use in this function.
     fn num_vregs(&self) -> usize;
 
+    /// Get the register class of a given VReg index.
+    fn vreg_regclass(&self, idx: usize) -> RegClass;
+
     /// Get the VRegs that are pointer/reference types. This has the
     /// following effects for each such vreg:
     ///


### PR DESCRIPTION
Currently, we infer this from the first def we see of a vreg, but this
is somewhat brittle, as I have found when debugging the integration of
regalloc2 with Cranelift. It would be better to just obtain the register
class for each vreg directly from the embedder. This is a small change
that should be a direct type lookup in most embedders.