### PR TITLE
Generalize debug-info support a bit.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,9 +962,7 @@ pub trait Function {
     /// The instruction indices imply a program point just *before*
     /// the instruction.
     ///
-    /// Preconditions: we require this slice to be sorted in
-    /// lexicographic order (i.e., first by vreg, then by instruction
-    /// index), and we require the ranges to be non-overlapping.
+    /// Precondition: we require this slice to be sorted in by vreg.
     fn debug_value_labels(&self) -> &[(VReg, Inst, Inst, u32)] {
         &[]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,7 +962,7 @@ pub trait Function {
     /// The instruction indices imply a program point just *before*
     /// the instruction.
     ///
-    /// Precondition: we require this slice to be sorted in by vreg.
+    /// Precondition: we require this slice to be sorted by vreg.
     fn debug_value_labels(&self) -> &[(VReg, Inst, Inst, u32)] {
         &[]
     }


### PR DESCRIPTION
Previously, debug value-label support required each vreg to have a
disjoint sequence of instruction ranges, each with one label.

Unfortunately, it's entirely possible for multiple values at the program
level to map to one vreg at the IR level, leading to multiple labels.

This PR generalizes the debug-info generation support to allow for
arbitrary (label, range, vreg) tuples, as long as they are sorted by
vreg, with no other requirements. The lookup is a little more costly
when we generate the debuginfo, but in practice we shouldn't have more
than a *few* debug value labels per vreg, so in practice the constants
should be small.