### PR TITLE
Bump version to 0.1.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This will include #40 in a release to allow us to use it in Cranelift's bytecodealliance/wasmtime#3989.