### PR TITLE
Bump version to 0.1.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This will get #43 into a release to allow us to use the checker on
Cranelift outputs.