### PR TITLE
Handle conflict-related liverange splits arising from stack constraints without falling back to spill bundle.

### DIFF
--- a/src/ion/requirement.rs
+++ b/src/ion/requirement.rs
@@ -38,6 +38,7 @@ pub enum RequirementConflictAt {
 }
 
 impl RequirementConflictAt {
+    #[inline(always)]
     pub fn should_trim_edges_around_split(self) -> bool {
         match self {
             RequirementConflictAt::RegToStack(..) | RequirementConflictAt::StackToReg(..) => false,
@@ -45,6 +46,7 @@ impl RequirementConflictAt {
         }
     }
 
+    #[inline(always)]
     pub fn suggested_split_point(self) -> ProgPoint {
         match self {
             RequirementConflictAt::RegToStack(pt)
@@ -83,6 +85,7 @@ impl Requirement {
         }
     }
 
+    #[inline(always)]
     pub fn is_stack(self) -> bool {
         match self {
             Requirement::Stack | Requirement::FixedStack(..) => true,
@@ -91,6 +94,7 @@ impl Requirement {
         }
     }
 
+    #[inline(always)]
     pub fn is_reg(self) -> bool {
         match self {
             Requirement::Register | Requirement::FixedReg(..) => true,


### PR DESCRIPTION
Currently, we unconditionally trim the ends of liveranges around a split
when we do a split, including splits due to conflicts in a
liverange/bundle's requirements (e.g., a liverange with both a register
and a stack use). These trimmed ends, if they exist, go to the spill
bundle, and the spill bundle may receive a register during second-chance
allocation or otherwise will receive a stack slot.

This was previously measured to reduce contention significantly, because
it reduces the sizes of liveranges that participate in the first-chance
competition for allocations. When a split has to occur, we might as well
relegate the "connecting pieces" to a process that comes later, with a
hint to try to get the right register if possible but no hard connection
to either end.

However, in the case of a split arising from a reg-to-stack /
stack-to-reg conflict, as happens when references are used or def'd as
registers and then cross safepoints, this extra step in the connectivity
(normal LR with register use, then spill bundle, then normal LR with
stack use) can lead to extra moves. Additionally, when one of the LRs
has a stack constraint, contention is far less important; so it doesn't
hurt to skip the trimming step. In fact, it's likely much better to put
the "connecting piece" together with the stack side of the conflict.

Ideally we would handle this with the same move-cost logic we use for
conflicts detected during backtracking, but the requirements-related
splitting happens separately and that logic would need to be generalized
further. For now, this is sufficient to eliminate redundant moves as
seen in e.g. bytecodealliance/wasmtime#3785.

Fixes #48.