### PR TITLE
Bump to version 0.1.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
Bumping version in order to release 0.1.3 with #49 included.