### PR TITLE
Bump version to 0.2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.1.3"
+version = "0.2.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
The change in #51 was API-visible (removal of the "scratch register"
field in the `Env`) so this is a semver bump.