### PR TITLE
Handle conflicting Before and After fixed-reg constraints with a copy.

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -274,8 +274,18 @@ pub struct MultiFixedRegFixup {
     pub pos: ProgPoint,
     pub from_slot: u8,
     pub to_slot: u8,
+    pub level: FixedRegFixupLevel,
     pub to_preg: PRegIndex,
     pub vreg: VRegIndex,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FixedRegFixupLevel {
+    /// A fixup copy for the initial fixed reg; must come first.
+    Initial,
+    /// A fixup copy from the first fixed reg to other fixed regs for
+    /// the same vreg; must come second.
+    Secondary,
 }
 
 /// The field order is significant: these are sorted so that a
@@ -564,7 +574,8 @@ pub enum InsertMovePrio {
     BlockParam,
     Regular,
     PostRegular,
-    MultiFixedReg,
+    MultiFixedRegInitial,
+    MultiFixedRegSecondary,
     ReusedInput,
     OutEdgeMoves,
 }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -991,6 +991,13 @@ impl<'a, F: Function> Env<'a, F> {
                                     // rewrite here without the
                                     // constraint. See #53.
                                     //
+                                    // Note that we need to create a
+                                    // reservation in the allocation
+                                    // map for the given preg, because
+                                    // it still must not be used by
+                                    // some other vreg at the
+                                    // use-site.
+                                    //
                                     // Note that we handle multiple
                                     // conflicting constraints for the
                                     // same vreg in a separate pass
@@ -1010,6 +1017,16 @@ impl<'a, F: Function> Env<'a, F> {
                                             operand.kind(),
                                             operand.pos(),
                                         );
+
+                                        let range = CodeRange {
+                                            from: pos,
+                                            to: pos.next(),
+                                        };
+                                        let lrkey = LiveRangeKey::from_range(&range);
+                                        self.pregs[preg.index()]
+                                            .allocations
+                                            .btree
+                                            .insert(lrkey, LiveRangeIndex::invalid());
                                     }
                                 }
                             }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -25,7 +25,7 @@ use crate::{
     Allocation, Block, Function, Inst, InstPosition, Operand, OperandConstraint, OperandKind,
     OperandPos, PReg, ProgPoint, RegAllocError, VReg,
 };
-use fxhash::FxHashSet;
+use fxhash::{FxHashMap, FxHashSet};
 use slice_group_by::GroupByMut;
 use smallvec::{smallvec, SmallVec};
 use std::collections::{HashSet, VecDeque};
@@ -919,18 +919,110 @@ impl<'a, F: Function> Env<'a, F> {
                     continue;
                 }
 
+                // Preprocess defs and uses. Specifically, if there
+                // are any fixed-reg-constrained defs at Late position
+                // and fixed-reg-constrained uses at Early position
+                // with the same preg, we need to (i) add a fixup move
+                // for the use, (ii) rewrite the use to have an Any
+                // constraint, and (ii) move the def to Early position
+                // to reserve the register for the whole instruction.
+                let mut operand_rewrites: FxHashMap<usize, Operand> = FxHashMap::default();
+                let mut late_def_fixed: SmallVec<[(PReg, Operand, usize); 2]> = smallvec![];
+                for (i, &operand) in self.func.inst_operands(inst).iter().enumerate() {
+                    if let OperandConstraint::FixedReg(preg) = operand.constraint() {
+                        match operand.pos() {
+                            OperandPos::Late => {
+                                // See note in fuzzing/func.rs: we
+                                // can't allow this, because there
+                                // would be no way to move a value
+                                // into place for a late use *after*
+                                // the early point (i.e. in the middle
+                                // of the instruction).
+                                assert!(
+                                    operand.kind() == OperandKind::Def,
+                                    "Invalid operand: fixed constraint on Use/Mod at Late point"
+                                );
+
+                                late_def_fixed.push((preg, operand, i));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                for (i, &operand) in self.func.inst_operands(inst).iter().enumerate() {
+                    if let OperandConstraint::FixedReg(preg) = operand.constraint() {
+                        match operand.pos() {
+                            OperandPos::Early => {
+                                assert!(operand.kind() == OperandKind::Use,
+                                            "Invalid operand: fixed constraint on Def/Mod at Early position");
+
+                                // If we have a constraint at the
+                                // Early point for a fixed preg, and
+                                // this preg is also constrained with
+                                // a *separate* def at Late, and *if*
+                                // the vreg is live downward, we have
+                                // to use the multi-fixed-reg
+                                // mechanism for a fixup and rewrite
+                                // here without the constraint. See
+                                // #53.
+                                //
+                                // We adjust the def liverange and Use
+                                // to an "early" position to reserve
+                                // the register, it still must not be
+                                // used by some other vreg at the
+                                // use-site.
+                                //
+                                // Note that we handle multiple
+                                // conflicting constraints for the
+                                // same vreg in a separate pass (see
+                                // `fixup_multi_fixed_vregs` below).
+                                if let Some((_, def_op, def_slot)) = late_def_fixed
+                                    .iter()
+                                    .find(|(def_preg, _, _)| *def_preg == preg)
+                                {
+                                    let pos = ProgPoint::before(inst);
+                                    self.multi_fixed_reg_fixups.push(MultiFixedRegFixup {
+                                        pos,
+                                        from_slot: i as u8,
+                                        to_slot: i as u8,
+                                        to_preg: PRegIndex::new(preg.index()),
+                                        vreg: VRegIndex::new(operand.vreg().vreg()),
+                                        level: FixedRegFixupLevel::Initial,
+                                    });
+
+                                    operand_rewrites.insert(
+                                        i,
+                                        Operand::new(
+                                            operand.vreg(),
+                                            OperandConstraint::Any,
+                                            operand.kind(),
+                                            operand.pos(),
+                                        ),
+                                    );
+                                    operand_rewrites.insert(
+                                        *def_slot,
+                                        Operand::new(
+                                            def_op.vreg(),
+                                            def_op.constraint(),
+                                            def_op.kind(),
+                                            OperandPos::Early,
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
                 // Process defs and uses.
-
-                // Track fixed PRegs at After; we need to avoid
-                // creating fixed constraints at Before with the same
-                // regs if the corresponding vreg is live
-                // downward. (See #53.)
-                let mut fixed_after_pregs: SmallVec<[PReg; 4]> = smallvec![];
-
                 for &cur_pos in &[InstPosition::After, InstPosition::Before] {
                     for i in 0..self.func.inst_operands(inst).len() {
                         // don't borrow `self`
-                        let mut operand = self.func.inst_operands(inst)[i];
+                        let operand = operand_rewrites
+                            .get(&i)
+                            .cloned()
+                            .unwrap_or(self.func.inst_operands(inst)[i]);
                         let pos = match (operand.kind(), operand.pos()) {
                             (OperandKind::Mod, _) => ProgPoint::before(inst),
                             (OperandKind::Def, OperandPos::Early) => ProgPoint::before(inst),
@@ -962,78 +1054,6 @@ impl<'a, F: Function> Env<'a, F> {
                             pos,
                             operand
                         );
-
-                        if let OperandConstraint::FixedReg(preg) = operand.constraint() {
-                            match operand.pos() {
-                                OperandPos::Late => {
-                                    // See note in fuzzing/func.rs: we
-                                    // can't allow this, because there
-                                    // would be no way to move a value
-                                    // into place for a late use
-                                    // *after* the early point
-                                    // (i.e. in the middle of the
-                                    // instruction).
-                                    assert!(operand.kind() == OperandKind::Def,
-                                            "Invalid operand: fixed constraint on Use/Mod at Late point");
-
-                                    fixed_after_pregs.push(preg);
-                                }
-                                OperandPos::Early => {
-                                    assert!(operand.kind() == OperandKind::Use,
-                                            "Invalid operand: fixed constraint on Def/Mod at Early position");
-
-                                    // If we have a constraint at the
-                                    // Early point for a fixed preg,
-                                    // and this preg is also
-                                    // constrained with a *separate*
-                                    // def at Late, and *if* the vreg
-                                    // is live downward, we have to
-                                    // use the multi-fixed-reg
-                                    // mechanism for a fixup and
-                                    // rewrite here without the
-                                    // constraint. See #53.
-                                    //
-                                    // Note that we need to create a
-                                    // reservation in the allocation
-                                    // map for the given preg, because
-                                    // it still must not be used by
-                                    // some other vreg at the
-                                    // use-site.
-                                    //
-                                    // Note that we handle multiple
-                                    // conflicting constraints for the
-                                    // same vreg in a separate pass
-                                    // (see `fixup_multi_fixed_vregs`
-                                    // below).
-                                    if fixed_after_pregs.contains(&preg) {
-                                        self.multi_fixed_reg_fixups.push(MultiFixedRegFixup {
-                                            pos,
-                                            from_slot: i as u8,
-                                            to_slot: i as u8,
-                                            to_preg: PRegIndex::new(preg.index()),
-                                            vreg: VRegIndex::new(operand.vreg().vreg()),
-                                            level: FixedRegFixupLevel::Initial,
-                                        });
-                                        operand = Operand::new(
-                                            operand.vreg(),
-                                            OperandConstraint::Any,
-                                            operand.kind(),
-                                            operand.pos(),
-                                        );
-
-                                        let range = CodeRange {
-                                            from: pos,
-                                            to: pos.next(),
-                                        };
-                                        let lrkey = LiveRangeKey::from_range(&range);
-                                        self.pregs[preg.index()]
-                                            .allocations
-                                            .btree
-                                            .insert(lrkey, LiveRangeIndex::invalid());
-                                    }
-                                }
-                            }
-                        }
 
                         match operand.kind() {
                             OperandKind::Def | OperandKind::Mod => {

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -18,7 +18,9 @@ use super::{
     SpillSetIndex, Use, VRegData, VRegIndex, SLOT_NONE,
 };
 use crate::indexset::IndexSet;
-use crate::ion::data_structures::{BlockparamIn, BlockparamOut, MultiFixedRegFixup};
+use crate::ion::data_structures::{
+    BlockparamIn, BlockparamOut, FixedRegFixupLevel, MultiFixedRegFixup,
+};
 use crate::{
     Allocation, Block, Function, Inst, InstPosition, Operand, OperandConstraint, OperandKind,
     OperandPos, PReg, ProgPoint, RegAllocError, VReg,
@@ -564,7 +566,7 @@ impl<'a, F: Function> Env<'a, F> {
 
                                 self.insert_move(
                                     ProgPoint::before(inst),
-                                    InsertMovePrio::MultiFixedReg,
+                                    InsertMovePrio::MultiFixedRegInitial,
                                     Allocation::reg(src_preg),
                                     Allocation::reg(dst_preg),
                                     Some(dst.vreg()),
@@ -712,7 +714,7 @@ impl<'a, F: Function> Env<'a, F> {
                                         );
                                         self.insert_move(
                                             ProgPoint::before(inst.next()),
-                                            InsertMovePrio::MultiFixedReg,
+                                            InsertMovePrio::MultiFixedRegInitial,
                                             Allocation::reg(preg),
                                             Allocation::reg(preg),
                                             Some(src.vreg()),
@@ -1010,6 +1012,7 @@ impl<'a, F: Function> Env<'a, F> {
                                             to_slot: i as u8,
                                             to_preg: PRegIndex::new(preg.index()),
                                             vreg: VRegIndex::new(operand.vreg().vreg()),
+                                            level: FixedRegFixupLevel::Initial,
                                         });
                                         operand = Operand::new(
                                             operand.vreg(),
@@ -1364,6 +1367,7 @@ impl<'a, F: Function> Env<'a, F> {
                                 to_slot: u.slot,
                                 to_preg: preg_idx,
                                 vreg: vreg_idx,
+                                level: FixedRegFixupLevel::Secondary,
                             });
                             u.operand = Operand::new(
                                 u.operand.vreg(),

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -17,7 +17,7 @@ use super::{
     VRegIndex, SLOT_NONE,
 };
 use crate::ion::data_structures::{
-    BlockparamIn, BlockparamOut, CodeRange, LiveRangeKey, PosWithPrio,
+    BlockparamIn, BlockparamOut, CodeRange, FixedRegFixupLevel, LiveRangeKey, PosWithPrio,
 };
 use crate::ion::reg_traversal::RegTraversalIter;
 use crate::moves::{MoveAndScratchResolver, ParallelMoves};
@@ -749,9 +749,13 @@ impl<'a, F: Function> Env<'a, F> {
                 to_alloc,
                 fixup.vreg.index(),
             );
+            let prio = match fixup.level {
+                FixedRegFixupLevel::Initial => InsertMovePrio::MultiFixedRegInitial,
+                FixedRegFixupLevel::Secondary => InsertMovePrio::MultiFixedRegSecondary,
+            };
             self.insert_move(
                 fixup.pos,
-                InsertMovePrio::MultiFixedReg,
+                prio,
                 from_alloc,
                 to_alloc,
                 Some(self.vreg(fixup.vreg)),

--- a/src/moves.rs
+++ b/src/moves.rs
@@ -368,17 +368,17 @@ where
 
         // Now, find a scratch allocation in order to resolve cycles.
         let scratch = (self.find_free_reg)().unwrap_or_else(|| (self.get_stackslot)());
-        log::trace!("scratch resolver: scratch alloc {:?}", scratch);
+        trace!("scratch resolver: scratch alloc {:?}", scratch);
 
         let moves = moves.with_scratch(scratch);
         for &(src, dst, data) in &moves {
             // Do we have a stack-to-stack move? If so, resolve.
             if src.is_stack() && dst.is_stack() {
-                log::trace!("scratch resolver: stack to stack: {:?} -> {:?}", src, dst);
+                trace!("scratch resolver: stack to stack: {:?} -> {:?}", src, dst);
                 // Lazily allocate a stack-to-stack scratch.
                 if self.stack_stack_scratch_reg.is_none() {
                     if let Some(reg) = (self.find_free_reg)() {
-                        log::trace!(
+                        trace!(
                             "scratch resolver: have free stack-to-stack scratch preg: {:?}",
                             reg
                         );
@@ -386,7 +386,7 @@ where
                     } else {
                         self.stack_stack_scratch_reg = Some(Allocation::reg(self.victim));
                         self.stack_stack_scratch_reg_save = Some((self.get_stackslot)());
-                        log::trace!("scratch resolver: stack-to-stack using victim {:?} with save stackslot {:?}",
+                        trace!("scratch resolver: stack-to-stack using victim {:?} with save stackslot {:?}",
                                     self.stack_stack_scratch_reg,
                                     self.stack_stack_scratch_reg_save);
                     }
@@ -422,7 +422,7 @@ where
             }
         }
 
-        log::trace!("scratch resolver: got {:?}", result);
+        trace!("scratch resolver: got {:?}", result);
         result
     }
 }


### PR DESCRIPTION
This fixes #53. Previously, if two operands on an instruction
specified *different* vregs constrained to the same physical register
at the Before (Early) and After (Late) points of the instruction, and
the Before was live downward as well, we would panic: we can't insert
a move into the middle of an instruction, so putting the first vreg in
the preg at Early implies we have an unsolveable conflict at Late.

We can solve this issue by adding some new logic to insert a copy, and
rewrite the constraint. This reuses the multi-fixed-reg-constraint
fixup logic. While that logic handles the case where the *same* vreg
has multiple *different* fixed-reg constraints, this new logic
handles *different* vregs with the *same* fixed-reg constraints, but
at different *program points*; so the two are complementary.

This addresses the specific test case in #53, and also fuzzes cleanly
with the change to the fuzz testcase generator to generate these
cases (which also immediately found the bug).