### PR TITLE
Fix spillslot allocation to actually reuse spillslots.

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -447,6 +447,19 @@ pub struct SpillSlotList {
     pub probe_start: usize,
 }
 
+impl SpillSlotList {
+    /// Get the next spillslot index in probing order, wrapping around
+    /// at the end of the slots list.
+    pub(crate) fn next_index(&self, index: usize) -> usize {
+        debug_assert!(index < self.slots.len());
+        if index == self.slots.len() - 1 {
+            0
+        } else {
+            index + 1
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PrioQueue {
     pub heap: std::collections::BinaryHeap<PrioQueueEntry>,

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -439,13 +439,12 @@ pub struct SpillSlotData {
     pub ranges: LiveRangeSet,
     pub class: RegClass,
     pub alloc: Allocation,
-    pub next_spillslot: SpillSlotIndex,
 }
 
 #[derive(Clone, Debug)]
 pub struct SpillSlotList {
-    pub first_spillslot: SpillSlotIndex,
-    pub last_spillslot: SpillSlotIndex,
+    pub slots: SmallVec<[SpillSlotIndex; 32]>,
+    pub probe_start: usize,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The old logic, which did some linked-list rearranging to try to probe
more-likely-to-be-free slots first and which was inherited straight from
the original IonMonkey allocator, was slightly broken (error in
translation and not in IonMonkey, to be clear): it did not get the
list-splicing right, so quite often dropped a slot on the floor and
failed to consider it for further reuse.

On some experimentation, it seems to work just as well to keep a
SmallVec of spillslot indices per size class instead, and save the last
probe-point in order to spread load throughout the allocated slots while
limiting the number of probes (to bound quadratic behavior).

This change moves the maximum slot count from 285 to 92 in `python.wasm`
from bytecodealliance/wasmtime#4214, and the maximum frame size from
2384 bytes to 752 bytes.

Sightglass results with Cranelift: no differences except on SpiderMonkey
(presumably because of very large stack frames in main interpreter loop):

```plain
compilation :: nanoseconds :: benchmarks-next/spidermonkey/benchmark.wasm

  Δ = 322649484.40 ± 276150647.93 (confidence = 99%)

  new.so is 1.01x to 1.11x faster than old.so!
  old.so is 0.90x to 0.99x faster than new.so!

  [5265054121 5522371452.20 5790849036] new.so
  [5773919099 5845020936.60 5921755485] old.so

compilation :: cycles :: benchmarks-next/spidermonkey/benchmark.wasm

  Δ = 1226157217.60 ± 1049578146.87 (confidence = 99%)

  new.so is 1.01x to 1.11x faster than old.so!
  old.so is 0.90x to 0.99x faster than new.so!

  [20009188534 20987183251.80 22007591586] new.so
  [21943062532 22213340469.40 22505025114] old.so

execution :: nanoseconds :: benchmarks-next/spidermonkey/benchmark.wasm

  Δ = 83516918.70 ± 67008953.30 (confidence = 99%)

  new.so is 1.00x to 1.04x faster than old.so!
  old.so is 0.96x to 1.00x faster than new.so!

  [3473341325 3579943166.40 3666372097] new.so
  [3570475540 3663460085.10 3737485602] old.so

execution :: cycles :: benchmarks-next/spidermonkey/benchmark.wasm

  Δ = 317375574.40 ± 254647615.25 (confidence = 99%)

  new.so is 1.00x to 1.04x faster than old.so!
  old.so is 0.96x to 1.00x faster than new.so!

  [13200115708 13605189187.20 13933711484] new.so
  [13569226542 13922564761.60 14203849912] old.so
```