### PR TITLE
Clobbers: use a more efficient bitmask representation in API.

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -935,7 +935,7 @@ impl<'a, F: Function> Checker<'a, F> {
         else if !self.f.is_branch(inst) {
             let operands: Vec<_> = self.f.inst_operands(inst).iter().cloned().collect();
             let allocs: Vec<_> = out.inst_allocs(inst).iter().cloned().collect();
-            let clobbers: Vec<_> = self.f.inst_clobbers(inst).iter().cloned().collect();
+            let clobbers: Vec<_> = self.f.inst_clobbers(inst).into_iter().collect();
             let checkinst = CheckerInst::Op {
                 inst,
                 operands,

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     domtree, postorder, Allocation, Block, Function, Inst, InstRange, MachineEnv, Operand,
-    OperandConstraint, OperandKind, OperandPos, PReg, RegClass, VReg,
+    OperandConstraint, OperandKind, OperandPos, PReg, PRegMask, RegClass, VReg,
 };
 
 use arbitrary::Result as ArbitraryResult;
@@ -132,8 +132,12 @@ impl Function for Func {
         &self.insts[insn.index()].operands[..]
     }
 
-    fn inst_clobbers(&self, insn: Inst) -> &[PReg] {
-        &self.insts[insn.index()].clobbers[..]
+    fn inst_clobbers(&self, insn: Inst) -> PRegMask {
+        let mut mask = PRegMask::default();
+        for &preg in &self.insts[insn.index()].clobbers {
+            mask = mask.with(preg);
+        }
+        mask
     }
 
     fn num_vregs(&self) -> usize {

--- a/src/ion/dump.rs
+++ b/src/ion/dump.rs
@@ -95,7 +95,7 @@ impl<'a, F: Function> Env<'a, F> {
                 let clobbers = self
                     .func
                     .inst_clobbers(inst)
-                    .iter()
+                    .into_iter()
                     .map(|preg| format!("{}", preg))
                     .collect::<Vec<_>>();
                 let allocs = (0..ops.len())

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -491,9 +491,7 @@ impl<'a, F: Function> Env<'a, F> {
             // operands and clobbers.
             for inst in insns.rev().iter() {
                 // Mark clobbers with CodeRanges on PRegs.
-                for i in 0..self.func.inst_clobbers(inst).len() {
-                    // don't borrow `self`
-                    let clobber = self.func.inst_clobbers(inst)[i];
+                for clobber in self.func.inst_clobbers(inst) {
                     // Clobber range is at After point only: an
                     // instruction can still take an input in a reg
                     // that it later clobbers. (In other words, the

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -950,7 +950,7 @@ impl<'a, F: Function> Env<'a, F> {
                     }
                 }
                 for reg in this.func.inst_clobbers(inst) {
-                    redundant_moves.clear_alloc(Allocation::reg(*reg));
+                    redundant_moves.clear_alloc(Allocation::reg(reg));
                 }
             }
         }


### PR DESCRIPTION
Currently, the `Function` trait requires a `&[PReg]` for the
clobber-list for a given instruction. In most cases where clobbers are
used, the list may be long: e.g., ABIs specify a fixed set of registers
that are clobbered and there may be ~half of all registers in this list.
What's more, the list can't be shared for e.g. all calls of a given ABI,
because actual return-values (defs) can't be clobbers. So we need to
allocate space for long, sometimes-slightly-different lists; this is
inefficient for the embedder and for us.

It's much more efficient to use a bitmask to represent a set of physical
registers. With current data structure bitpacking limitations, we can
support at most 128 physical registers; this means we can use a `u128`
bitmask. This also allows e.g. an embedder to start with a constant for
a given ABI, and mask out bits for actual return-value registers on call
instructions.

This PR makes that change, for minor but positive performance impact.