### PR TITLE
Version 0.2.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This allows us to make a point-release of regalloc2 and consequently also of Cranelift to incorporate the fix in #60.