### PR TITLE
Streamline log enablement

### DIFF
--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -97,7 +97,7 @@ impl<'a, F: Function> Env<'a, F> {
         self.fixup_multi_fixed_vregs();
         self.merge_vreg_bundles();
         self.queue_bundles();
-        if log::log_enabled!(log::Level::Trace) {
+        if trace_enabled!() {
             self.dump_state();
         }
         Ok(())

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -435,19 +435,17 @@ impl<'a, F: Function> Env<'a, F> {
                                     alloc,
                                 );
                                 #[cfg(debug_assertions)]
-                                {
-                                    if log::log_enabled!(log::Level::Trace) {
-                                        self.annotate(
-                                            self.cfginfo.block_entry[block.index()],
-                                            format!(
-                                                "blockparam-in: block{} to block{}:into v{} in {}",
-                                                from_block.index(),
-                                                to_block.index(),
-                                                to_vreg.index(),
-                                                alloc
-                                            ),
-                                        );
-                                    }
+                                if self.annotations_enabled {
+                                    self.annotate(
+                                        self.cfginfo.block_entry[block.index()],
+                                        format!(
+                                            "blockparam-in: block{} to block{}:into v{} in {}",
+                                            from_block.index(),
+                                            to_block.index(),
+                                            to_vreg.index(),
+                                            alloc
+                                        ),
+                                    );
                                 }
                             }
                             blockparam_in_idx += 1;
@@ -831,16 +829,11 @@ impl<'a, F: Function> Env<'a, F> {
                     );
                     if input_alloc != output_alloc {
                         #[cfg(debug_assertions)]
-                        {
-                            if log::log_enabled!(log::Level::Trace) {
-                                self.annotate(
-                                    ProgPoint::before(inst),
-                                    format!(
-                                        " reuse-input-copy: {} -> {}",
-                                        input_alloc, output_alloc
-                                    ),
-                                );
-                            }
+                        if self.annotations_enabled {
+                            self.annotate(
+                                ProgPoint::before(inst),
+                                format!(" reuse-input-copy: {} -> {}", input_alloc, output_alloc),
+                            );
                         }
                         let input_operand = self.func.inst_operands(inst)[input_idx];
                         self.insert_move(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@ macro_rules! trace {
     };
 }
 
+macro_rules! trace_enabled {
+    () => {
+        cfg!(feature = "trace-log")
+    };
+}
+
 pub(crate) mod cfg;
 pub(crate) mod domtree;
 pub mod indexset;


### PR DESCRIPTION
Two small changes related to logging, that try to simplify reasoning about how logs are enabled a bit:

- `annotate` already has a guard in the beginning of its body, checking if `annotations_enabled` is true. Most uses of this function aren't additionally guarded with `if log::log_enabled!(log::Level::Trace)`, so for consistency and since there's already the `enabled_annotations` guard, I've removed the extra `log_enabled` checks (in two places).
- `dump_state` uses the crate-defined `trace` macro that checks against the `trace-log` feature, but the check on top of `dump_state` uses the `log_enabled` check. Instead I've introduced another macro similar to `log::log_enabled` that follows the same logic as the crate-defined `trace` macro to decide whether to enter the block or not.