### PR TITLE
Only record vreg definitions when fuzzing

### DIFF
--- a/src/fuzzing/mod.rs
+++ b/src/fuzzing/mod.rs
@@ -6,6 +6,7 @@
 //! Utilities for fuzzing.
 
 pub mod func;
+pub mod ssa;
 
 // Re-exports for fuzz targets.
 
@@ -20,9 +21,6 @@ pub mod moves {
 }
 pub mod cfg {
     pub use crate::cfg::*;
-}
-pub mod ssa {
-    pub use crate::ssa::*;
 }
 pub mod ion {
     pub use crate::ion::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub mod indexset;
 pub(crate) mod ion;
 pub(crate) mod moves;
 pub(crate) mod postorder;
-pub(crate) mod ssa;
 
 #[macro_use]
 mod index;


### PR DESCRIPTION
The `vreg_def_blockparam` and `vreg_def_inst` fields on CFGInfo are only
used in `validate_ssa`, which in turn is only used in the ssagen fuzz
target.

Since these fields are never read in normal usage, initializing them is
entirely wasted effort. According to valgrind/DHAT, when running
`wasmtime compile` on the Sightglass Spidermonkey benchmark, removing
these fields saves about 100M instructions, 23k heap allocations
totalling 40MiB, and 47MiB of writes to the heap.

I tested the fuzz target for a few minutes, and also tested a release build of wasmtime. So I've built with the fuzzing feature both on and off, and there weren't any build warnings or errors in either case.