### PR TITLE
Some fixes to allow for call instructions to name args, returns, and clobbers with constraints.

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -53,6 +53,14 @@ impl CodeRange {
     pub fn len(&self) -> usize {
         self.to.inst().index() - self.from.inst().index()
     }
+    /// Returns the range covering just one program point.
+    #[inline(always)]
+    pub fn singleton(pos: ProgPoint) -> CodeRange {
+        CodeRange {
+            from: pos,
+            to: pos.next(),
+        }
+    }
 }
 
 impl std::cmp::PartialOrd for CodeRange {

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -185,7 +185,7 @@ pub struct LiveBundle {
     pub spill_weight_and_props: u32,
 }
 
-pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 29) - 1;
+pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 28) - 1;
 pub const MINIMAL_FIXED_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT;
 pub const MINIMAL_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 1;
 pub const BUNDLE_MAX_NORMAL_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 2;
@@ -197,13 +197,15 @@ impl LiveBundle {
         spill_weight: u32,
         minimal: bool,
         fixed: bool,
+        fixed_def: bool,
         stack: bool,
     ) {
         debug_assert!(spill_weight <= BUNDLE_MAX_SPILL_WEIGHT);
         self.spill_weight_and_props = spill_weight
             | (if minimal { 1 << 31 } else { 0 })
             | (if fixed { 1 << 30 } else { 0 })
-            | (if stack { 1 << 29 } else { 0 });
+            | (if fixed_def { 1 << 29 } else { 0 })
+            | (if stack { 1 << 28 } else { 0 });
     }
 
     #[inline(always)]
@@ -217,8 +219,13 @@ impl LiveBundle {
     }
 
     #[inline(always)]
-    pub fn cached_stack(&self) -> bool {
+    pub fn cached_fixed_def(&self) -> bool {
         self.spill_weight_and_props & (1 << 29) != 0
+    }
+
+    #[inline(always)]
+    pub fn cached_stack(&self) -> bool {
+        self.spill_weight_and_props & (1 << 28) != 0
     }
 
     #[inline(always)]
@@ -227,13 +234,18 @@ impl LiveBundle {
     }
 
     #[inline(always)]
-    pub fn set_cached_stack(&mut self) {
+    pub fn set_cached_fixed_def(&mut self) {
         self.spill_weight_and_props |= 1 << 29;
     }
 
     #[inline(always)]
+    pub fn set_cached_stack(&mut self) {
+        self.spill_weight_and_props |= 1 << 28;
+    }
+
+    #[inline(always)]
     pub fn cached_spill_weight(&self) -> u32 {
-        self.spill_weight_and_props & ((1 << 29) - 1)
+        self.spill_weight_and_props & ((1 << 28) - 1)
     }
 }
 

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -988,6 +988,15 @@ impl<'a, F: Function> Env<'a, F> {
                                 // same vreg in a separate pass (see
                                 // `fixup_multi_fixed_vregs` below).
                                 if late_def_fixed.contains(&preg) {
+                                    log::trace!(
+                                        concat!(
+                                            "-> operand {:?} is fixed to preg {:?}, ",
+                                            "is downward live, and there is also a ",
+                                            "def at this preg"
+                                        ),
+                                        operand,
+                                        preg
+                                    );
                                     let pos = ProgPoint::before(inst);
                                     self.multi_fixed_reg_fixups.push(MultiFixedRegFixup {
                                         pos,

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -262,6 +262,7 @@ impl<'a, F: Function> Env<'a, F> {
 
         let minimal;
         let mut fixed = false;
+        let mut fixed_def = false;
         let mut stack = false;
         let bundledata = &self.bundles[bundle.index()];
         let first_range = bundledata.ranges[0].index;
@@ -277,11 +278,15 @@ impl<'a, F: Function> Env<'a, F> {
             for u in &first_range_data.uses {
                 trace!("  -> use: {:?}", u);
                 if let OperandConstraint::FixedReg(_) = u.operand.constraint() {
-                    trace!("  -> fixed use at {:?}: {:?}", u.pos, u.operand);
+                    trace!("  -> fixed operand at {:?}: {:?}", u.pos, u.operand);
                     fixed = true;
+                    if u.operand.kind() == OperandKind::Def {
+                        trace!("  -> is fixed def");
+                        fixed_def = true;
+                    }
                 }
                 if let OperandConstraint::Stack = u.operand.constraint() {
-                    trace!("  -> stack use at {:?}: {:?}", u.pos, u.operand);
+                    trace!("  -> stack operand at {:?}: {:?}", u.pos, u.operand);
                     stack = true;
                 }
                 if stack && fixed {
@@ -340,6 +345,7 @@ impl<'a, F: Function> Env<'a, F> {
             spill_weight,
             minimal,
             fixed,
+            fixed_def,
             stack,
         );
     }

--- a/src/ion/requirement.rs
+++ b/src/ion/requirement.rs
@@ -130,7 +130,7 @@ impl<'a, F: Function> Env<'a, F> {
         trace!("compute_requirement: {:?}", bundle);
         let ranges = &self.bundles[bundle.index()].ranges;
         for entry in ranges {
-            trace!(" -> LR {:?}", entry.index);
+            trace!(" -> LR {:?}: {:?}", entry.index, entry.range);
             for u in &self.ranges[entry.index.index()].uses {
                 trace!("  -> use {:?}", u);
                 let r = self.requirement_from_operand(u.operand);

--- a/src/ion/stackmap.rs
+++ b/src/ion/stackmap.rs
@@ -55,6 +55,7 @@ impl<'a, F: Function> Env<'a, F> {
                         safepoint_idx += 1;
                         continue;
                     }
+
                     trace!("    -> covers safepoint {:?}", safepoints[safepoint_idx]);
 
                     self.safepoint_slots


### PR DESCRIPTION
- Allow early-pos uses with fixed regs that conflict with clobbers (which happen at late-pos), in addition to the existing logic for conflicts with late-pos defs with fixed regs.

  This is a pretty subtle issue that was uncovered in #53 for the def case, and the fix here is the mirror of that fix for clobbers. The root cause for all this complexity is that we can't split in the middle of an instruction (because there's no way to insert a move there!) so if a use is live-downward, we can't let it live in preg A at early-pos and preg B != A at late-pos; instead we need to rewrite the constraints and use a fixup move.

  The earlier change to fix #53 was actually a bit too conservative in that it always applied when such conflicts existed, even if the downward arg was not live. This PR fixes that (it's fine for the early-use and late-def to be fixed to the same reg if the use's liverange ends after early-pos) and adapts the same flexibility to the clobbers case as well.

- Reworks the fixups for the def case mentioned above to not shift the def to the Early point. Doing so causes issues when the def is to a reffy vreg: it can then be falsely included in a stackmap if the instruction containing this operand is a safepoint.

- Fixes the last-resort split-bundle-into-minimal-pieces logic from #59 to properly limit a minimal bundle piece to end after the early-pos, rather than cover the entire instruction. This was causing artificial overlaps between args that end after early-pos and defs that start at late-pos when one of the vregs hit the fallback split behavior.