### PR TITLE
Support using pinned registers as blockparams

### DIFF
--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -332,6 +332,12 @@ impl<'a, F: Function> Env<'a, F> {
             let BlockparamOut {
                 from_vreg, to_vreg, ..
             } = self.blockparam_outs[i];
+            if self.func.is_pinned_vreg(self.vreg(from_vreg)).is_some()
+                || self.func.is_pinned_vreg(self.vreg(to_vreg)).is_some()
+            {
+                continue;
+            }
+
             trace!(
                 "trying to merge blockparam v{} with input v{}",
                 to_vreg.index(),


### PR DESCRIPTION
I use pinned registers to represent 2 things:
- The fixed zero register (e.g. `x0` on RISC-V, `xzr` on AArch64) which is hard-wired to zero.
	- This allows my `const_to_vreg` function to just return the pinned zero register instead of setting a register to 0.
- An abstract `undef` value which indicates that a value is never used.
	- This is used to represent values like `Option<i32>` which consist of a tag vreg and a value vreg. If the tag indicates `None` then the value is set to `undef`.
	- After regalloc, any move instructions with an `undef` input or output are eliminated.

These pinned registers are only ever used as instruction inputs (`use`) and blockparam outputs (jump arguments).

Making this work properly requires 2 changes:
- Blockparams can't be merged if the input or output is a pinned register. This is because the pinned registers aren't real registers: you can't write a value into them.
- Move generation needs to scan for blockparam uses of pinned registers to emit the required moves. (I suggest ignoring whitespace for reviewing, it makes the diff much easier to read).