### PR TITLE
Add fixed-non-allocatable operand support

### DIFF
--- a/fuzz/fuzz_targets/ion_checker.rs
+++ b/fuzz/fuzz_targets/ion_checker.rs
@@ -22,6 +22,7 @@ impl Arbitrary<'_> for TestCase {
                 &Options {
                     reused_inputs: true,
                     fixed_regs: true,
+                    fixed_nonallocatable: true,
                     clobbers: true,
                     control_flow: true,
                     reducible: false,

--- a/fuzz/fuzz_targets/ssagen.rs
+++ b/fuzz/fuzz_targets/ssagen.rs
@@ -23,6 +23,7 @@ impl Arbitrary<'_> for TestCase {
                 &Options {
                     reused_inputs: true,
                     fixed_regs: true,
+                    fixed_nonallocatable: true,
                     clobbers: true,
                     control_flow: true,
                     reducible: false,

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -270,6 +270,7 @@ fn choose_dominating_block(
 pub struct Options {
     pub reused_inputs: bool,
     pub fixed_regs: bool,
+    pub fixed_nonallocatable: bool,
     pub clobbers: bool,
     pub control_flow: bool,
     pub reducible: bool,
@@ -283,6 +284,7 @@ impl std::default::Default for Options {
         Options {
             reused_inputs: false,
             fixed_regs: false,
+            fixed_nonallocatable: false,
             clobbers: false,
             control_flow: true,
             reducible: false,
@@ -536,6 +538,8 @@ impl Func {
                         }
                         clobbers.push(PReg::new(reg, RegClass::Int));
                     }
+                } else if opts.fixed_nonallocatable && bool::arbitrary(u)? {
+                    operands.push(Operand::fixed_nonallocatable(PReg::new(63, RegClass::Int)));
                 }
 
                 let is_safepoint = opts.reftypes
@@ -658,7 +662,8 @@ pub fn machine_env() -> MachineEnv {
     }
     let preferred_regs_by_class: [Vec<PReg>; 2] = [regs(0..24), vec![]];
     let non_preferred_regs_by_class: [Vec<PReg>; 2] = [regs(24..32), vec![]];
-    let fixed_stack_slots = regs(32..64);
+    let fixed_stack_slots = regs(32..63);
+    // Register 63 is reserved for use as a fixed non-allocatable register.
     MachineEnv {
         preferred_regs_by_class,
         non_preferred_regs_by_class,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,6 +677,19 @@ impl Operand {
         )
     }
 
+    /// Create an `Operand` that always results in an assignment to the
+    /// given fixed `preg`, *without* tracking liveranges in that
+    /// `preg`. Must only be used for non-allocatable registers.
+    #[inline(always)]
+    pub fn fixed_nonallocatable(preg: PReg) -> Self {
+        Operand::new(
+            VReg::new(VReg::MAX, preg.class()),
+            OperandConstraint::FixedReg(preg),
+            OperandKind::Use,
+            OperandPos::Early,
+        )
+    }
+
     /// Get the virtual register designated by an operand. Every
     /// operand must name some virtual register, even if it constrains
     /// the operand to a fixed physical register as well; the vregs
@@ -741,6 +754,17 @@ impl Operand {
                 2 => OperandConstraint::Stack,
                 _ => unreachable!(),
             }
+        }
+    }
+
+    /// If this operand is for a fixed non-allocatable register (see
+    /// [`Operand::fixed`]), then returns the physical register that it will
+    /// be assigned to.
+    #[inline(always)]
+    pub fn as_fixed_nonallocatable(self) -> Option<PReg> {
+        match self.constraint() {
+            OperandConstraint::FixedReg(preg) if self.vreg().vreg() == VReg::MAX => Some(preg),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
This allows a non-allocatable `PReg` to be passed on directly to the allocations vector without any liverange tracking from the register allocator. The main intended use case is to support ISA-specific special registers such as a fixed zero register.

Fixes #3