### PR TITLE
Fix design doc typo

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -374,7 +374,7 @@ the Operand word (directly copied, so there is no need to dereference
 it); the ProgPoint at which the use occurs; the operand slot on that
 instruction, if any, that the operand comes from, and the use's
 'weight". (It's possible to have "ghost uses" that do not derive from
-any slot on the isntruction.) These four parts are packed into three
+any slot on the instruction.) These four parts are packed into three
 `u32`s: the slot can fit in 8 bits, and the weight in 16.
 
 The live-range carries its program-point range, uses, vreg index,


### PR DESCRIPTION
Feel free to ignore! I was reading over the design doc and noticed a typo. After the first, I was hoping to find more so the PR wouldn't be so trivial, but alas I didn't find anything else.