### PR TITLE
Version 0.4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.3.3"
+version = "0.4.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This is identical to v0.3.3, but it turns out that the removal of the register class from `SpillSlot` (#80) is an API change. I missed this and published 0.3.3 but yanked it after it was causing build issues for folks.