### PR TITLE
Fix fallback-split behavior: trim start of minimal bundle wrt start of original LR.

### DIFF
--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -800,6 +800,7 @@ impl<'a, F: Function> Env<'a, F> {
         for entry_idx in 0..self.bundles[bundle.index()].ranges.len() {
             // Iterate manually; don't borrow `self`.
             let entry = self.bundles[bundle.index()].ranges[entry_idx];
+            let lr_from = entry.range.from;
             let lr_to = entry.range.to;
 
             removed_lrs.insert(entry.index);
@@ -863,6 +864,7 @@ impl<'a, F: Function> Env<'a, F> {
 
                 // Otherwise, create a new LR.
                 let pos = ProgPoint::before(u.pos.inst());
+                let pos = std::cmp::max(lr_from, pos);
                 let cr = CodeRange { from: pos, to };
                 let lr = self.create_liverange(cr);
                 new_lrs.push((vreg, lr));


### PR DESCRIPTION
When a liverange starts at a *late* point of an instruction, and it undergoes the fallback "split into all minimal pieces" transform, we end up creating one minimal bundle that starts at the *early* point of the instruction at the start of the original LR. This can create impossible-to-allocate situations where a fixed-constraint LR overlaps another constrained to the same register (e.g. at calls). We fix this by ensuring the minimal bundle is trimmed only to the half of the instruction that overlaps the original LR.

This is analogous to the third fix in #74, but on the other end (start of LR rather than end of it).