### PR TITLE
 Modify a SmallVec inline size for UseList to be slightly larger.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bytecodealliance/regalloc2"
 
 [dependencies]
 log = { version = "0.4.8", default-features = false }
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 fxhash = "0.2.1"
 slice-group-by = "0.3.0"
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -101,7 +101,7 @@ pub struct LiveRangeListEntry {
 }
 
 pub type LiveRangeList = SmallVec<[LiveRangeListEntry; 4]>;
-pub type UseList = SmallVec<[Use; 2]>;
+pub type UseList = SmallVec<[Use; 4]>;
 
 #[derive(Clone, Debug)]
 pub struct LiveRange {


### PR DESCRIPTION
This PR updates the `UseList` type alias to a `SmallVec` with 4
`Use`s (which are 4 bytes each) rather than 2, because we get 16 bytes
of space "for free" in a `SmallVec` on a 64-bit machine.

This PR improves the compilation performance of Cranelift by 1% on
SpiderMonkey.wasm (measured on a Linux desktop with pinned CPU
frequency, and pinned to one core).

It's worth noting also that before making these changes, I explored
whether it would be possible to put the lists of uses and liveranges
in single large backing `Vec`s; the basic reason why we can't do this
is that during liverange construction, we append to many lists
concurrently. One could use a linked-list arrangement, and in fact RA2
did this early in its development; the separate `SmallVec`s were
better for performance overall because the cache locality wins when we
traverse the lists many times. It may still be worth investigating use
of an arena to allocate the vecs rather than the default heap allocator.