### PR TITLE
Some small perf improvements

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -630,6 +630,7 @@ pub struct PosWithPrio {
 }
 
 impl PosWithPrio {
+    #[inline]
     pub fn key(self) -> u64 {
         u64_key(self.pos.to_index(), self.prio)
     }

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -157,9 +157,8 @@ impl<'a, F: Function> Env<'a, F> {
                     // conflicts list.
                     let conflict_bundle = self.ranges[preg_range.index()].bundle;
                     trace!("   -> conflict bundle {:?}", conflict_bundle);
-                    if !self.conflict_set.contains(&conflict_bundle) {
+                    if self.conflict_set.insert(conflict_bundle) {
                         conflicts.push(conflict_bundle);
-                        self.conflict_set.insert(conflict_bundle);
                         max_conflict_weight = std::cmp::max(
                             max_conflict_weight,
                             self.bundles[conflict_bundle.index()].cached_spill_weight(),


### PR DESCRIPTION
According the Sightglass, these changes collectively are worth a 3% speedup by instructions retired, and 1-2% speedup by CPU cycles, when using Wasmtime to compile the bz2 and pulldown-cmark benchmarks. Hyperfine also reports a 2% speedup for each of the bz2, pulldown-cmark, and spidermonkey benchmarks.