### PR TITLE
Add explicit dependency on `libfuzzer-sys`

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ cargo-fuzz = true
 regalloc2 = { path = "../", features = ["fuzzing"] }
 log = { version = "0.4.8", default-features = false }
 env_logger = "0.8.3"
+libfuzzer-sys = "0.4.2"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
This fixes a build issue with the most recent version of `libfuzzer-sys` where the prior version of the `fuzz_target!` macro didn't need the crate as an explicit dependency but the latest version does.