### PR TITLE
Use maximum inline capacity available for `SmallVec<VRegIndex>` in `SpillSet`

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -264,9 +264,22 @@ pub struct BundleProperties {
     pub fixed: bool,
 }
 
+#[cfg(target_pointer_width = "64")]
+pub type VRegIndexList = SmallVec<[VRegIndex; 4]>;
+#[cfg(target_pointer_width = "32")]
+pub type VRegIndexList = SmallVec<[VRegIndex; 2]>;
+
+#[test]
+fn vreg_index_list_is_same_size_as_vec() {
+    assert_eq!(
+        std::mem::size_of::<VRegIndexList>(),
+        std::mem::size_of::<Vec<VRegIndex>>()
+    );
+}
+
 #[derive(Clone, Debug)]
 pub struct SpillSet {
-    pub vregs: SmallVec<[VRegIndex; 2]>,
+    pub vregs: VRegIndexList,
     pub slot: SpillSlotIndex,
     pub reg_hint: PReg,
     pub class: RegClass,


### PR DESCRIPTION
We were using 2, which is the maximum for 32-bit architectures, but on 64-bit architectures we can get 4 inline elements without growing the size of the `SmallVec`.

This is a statistically significant speed up, but is so small that our formatting of floats truncates it (so less than 1%).

```
compilation :: instructions-retired :: benchmarks/bz2/benchmark.wasm

  Δ = 3360297.85 ± 40136.18 (confidence = 99%)

  more-inline-capacity.so is 1.00x to 1.00x faster than main.so!

  [945563401 945906690.73 946043245] main.so
  [942192473 942546392.88 942729104] more-inline-capacity.so

compilation :: instructions-retired :: benchmarks/pulldown-cmark/benchmark.wasm

  Δ = 1780540.13 ± 39362.84 (confidence = 99%)

  more-inline-capacity.so is 1.00x to 1.00x faster than main.so!

  [1544990595 1545359408.41 1545626251] main.so
  [1543269057 1543578868.28 1543851201] more-inline-capacity.so

compilation :: instructions-retired :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 36577153.54 ± 243753.54 (confidence = 99%)

  more-inline-capacity.so is 1.00x to 1.00x faster than main.so!

  [33956158997 33957780594.50 33959538220] main.so
  [33919762415 33921203440.96 33923023358] more-inline-capacity.so
```