### PR TITLE
Remove mod operands.

### DIFF
--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -906,7 +906,7 @@ impl<'a, F: Function> Env<'a, F> {
                 let inst = Inst::new(inst);
                 for (i, op) in this.func.inst_operands(inst).iter().enumerate() {
                     match op.kind() {
-                        OperandKind::Def | OperandKind::Mod => {
+                        OperandKind::Def => {
                             let alloc = this.get_alloc(inst, i);
                             redundant_moves.clear_alloc(alloc);
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,14 +426,13 @@ impl std::fmt::Display for OperandConstraint {
     }
 }
 
-/// The "kind" of the operand: whether it reads a vreg (Use), writes a
-/// vreg (Def), or reads and then writes (Mod, for "modify").
+/// The "kind" of the operand: whether it reads a vreg (Use) orwrites
+/// a vreg (Def).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum OperandKind {
     Def = 0,
-    Mod = 1,
-    Use = 2,
+    Use = 1,
 }
 
 /// The "position" of the operand: where it has its read/write
@@ -488,7 +487,7 @@ pub enum OperandPos {
 pub struct Operand {
     /// Bit-pack into 32 bits.
     ///
-    /// constraint:7 kind:2 pos:1 class:1 vreg:21
+    /// constraint:7 kind:1 pos:1 class:2 vreg:21
     ///
     /// where `constraint` is an `OperandConstraint`, `kind` is an
     /// `OperandKind`, `pos` is an `OperandPos`, `class` is a
@@ -532,8 +531,8 @@ impl Operand {
         Operand {
             bits: vreg.vreg() as u32
                 | (class_field << 21)
-                | (pos_field << 22)
-                | (kind_field << 23)
+                | (pos_field << 23)
+                | (kind_field << 24)
                 | (constraint_field << 25),
         }
     }
@@ -719,7 +718,7 @@ impl Operand {
     /// Get the register class used by this operand.
     #[inline(always)]
     pub fn class(self) -> RegClass {
-        let class_field = (self.bits >> 21) & 1;
+        let class_field = (self.bits >> 21) & 3;
         match class_field {
             0 => RegClass::Int,
             1 => RegClass::Float,
@@ -727,15 +726,14 @@ impl Operand {
         }
     }
 
-    /// Get the "kind" of this operand: a definition (write), a use
-    /// (read), or a "mod" / modify (a read followed by a write).
+    /// Get the "kind" of this operand: a definition (write) or a use
+    /// (read).
     #[inline(always)]
     pub fn kind(self) -> OperandKind {
-        let kind_field = (self.bits >> 23) & 3;
+        let kind_field = (self.bits >> 24) & 1;
         match kind_field {
             0 => OperandKind::Def,
-            1 => OperandKind::Mod,
-            2 => OperandKind::Use,
+            1 => OperandKind::Use,
             _ => unreachable!(),
         }
     }
@@ -746,7 +744,7 @@ impl Operand {
     /// at "after", though there are cases where this is not true.
     #[inline(always)]
     pub fn pos(self) -> OperandPos {
-        let pos_field = (self.bits >> 22) & 1;
+        let pos_field = (self.bits >> 23) & 1;
         match pos_field {
             0 => OperandPos::Early,
             1 => OperandPos::Late,
@@ -808,8 +806,7 @@ impl std::fmt::Debug for Operand {
 impl std::fmt::Display for Operand {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match (self.kind(), self.pos()) {
-            (OperandKind::Def, OperandPos::Late)
-            | (OperandKind::Mod | OperandKind::Use, OperandPos::Early) => {
+            (OperandKind::Def, OperandPos::Late) | (OperandKind::Use, OperandPos::Early) => {
                 write!(f, "{:?}", self.kind())?;
             }
             _ => {
@@ -1058,8 +1055,8 @@ pub trait Function {
     /// it in a given PReg chosen by the client prior to regalloc.
     ///
     /// Every register written by an instruction must either
-    /// correspond to (be assigned to) an Operand of kind `Def` or
-    /// `Mod`, or else must be a "clobber".
+    /// correspond to (be assigned to) an Operand of kind `Def`, or
+    /// else must be a "clobber".
     ///
     /// This can be used to, for example, describe ABI-specified
     /// registers that are not preserved by a call instruction, or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ impl std::fmt::Display for OperandConstraint {
     }
 }
 
-/// The "kind" of the operand: whether it reads a vreg (Use) orwrites
+/// The "kind" of the operand: whether it reads a vreg (Use) or writes
 /// a vreg (Def).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -73,13 +73,6 @@ pub fn validate_ssa<F: Function>(f: &F, cfginfo: &CFGInfo) -> Result<(), RegAllo
                         // Check all the uses in this instruction
                         // first, before recording its defs below.
                     }
-                    OperandKind::Mod => {
-                        // Mod (modify) operands are not used in SSA,
-                        // but can be used by non-SSA code (e.g. with
-                        // the regalloc.rs compatibility shim).
-                        trace!("Unexpected mod {:?}", operand.vreg());
-                        return Err(RegAllocError::SSA(operand.vreg(), iix));
-                    }
                 }
             }
 


### PR DESCRIPTION
(Stacked on top of #108; only the second commit is the real change here.)

This PR removes "mod" or "modify" operands. regalloc2 currently supports non-SSA input -- that is, code with multiple defs for the same register -- and as part of this support, a kind of operand that both uses the old value of a vreg and redefines it with a new value.

This operand kind was included for compatibility with regalloc.rs, because quite a few instructions in Cranelift used it to naturally describe the machine-level semantics. (For example, on x86, most ALU instructions modify one operand to replace it with the result.)

However, we've been pushing to refactor toward pure-SSA input, and thanks to @elliottt's work in Cranelift, non-SSA support is no longer needed in regalloc2. Instead, instructions now use "reused-input" operand constraints: a new vreg is defined with the result, and constrained to be in the same allocation as the input vreg. The "mod operand" thus was split into two halves.

Since we now want to make use of the pure-SSA properties for other work (e.g., better splitting and simpler liverange-construction frontend by allowing overlapping LRs for one vreg), we should remove features that imply non-SSA input, including "mod" operands.

The main part of this PR should be a fairly straightforward mechanical change: it removes the `OperandKind` then deletes the cases that handle it.

In addition, since the `OperandKind` now needs only 1 bit instead of 2 in the 32-bit bitpacked `Operand` encoding, there was an opportunity to allocate this bit to some other purpose. I've opted to put it in the `RegClass` field, because there has been a latent need to define more than two register classes for some architectures.