### PR TITLE
Bump to version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
Bump the version to 0.6.0 for the next publish to crates.io.

This version removes pinned registers and mod operands, which requires the bump to 0.6.0.