### PR TITLE
Misc refactorings

### DIFF
--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -1029,7 +1029,7 @@ impl<'a, F: Function> Env<'a, F> {
 
     pub fn fixup_multi_fixed_vregs(&mut self) {
         // Do a fixed-reg cleanup pass: if there are any LiveRanges with
-        // multiple uses (or defs) at the same ProgPoint and there is
+        // multiple uses at the same ProgPoint and there is
         // more than one FixedReg constraint at that ProgPoint, we
         // need to record all but one of them in a special fixup list
         // and handle them later; otherwise, bundle-splitting to

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -959,12 +959,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
         }
 
-        for range in 0..self.ranges.len() {
-            self.ranges[range].uses.reverse();
-            debug_assert!(self.ranges[range]
-                .uses
-                .windows(2)
-                .all(|win| win[0].pos <= win[1].pos));
+        for range in &mut self.ranges {
+            range.uses.reverse();
+            debug_assert!(range.uses.windows(2).all(|win| win[0].pos <= win[1].pos));
         }
 
         // Insert safepoint virtual stack uses, if needed.

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -1151,15 +1151,13 @@ impl<'a, F: Function> Env<'a, F> {
                     }
                 }
 
-                for &(clobber, pos) in &extra_clobbers {
+                for (clobber, pos) in extra_clobbers.drain(..) {
                     let range = CodeRange {
                         from: pos,
                         to: pos.next(),
                     };
                     self.add_liverange_to_preg(range, clobber);
                 }
-
-                extra_clobbers.clear();
             }
         }
     }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -334,8 +334,7 @@ impl<'a, F: Function> Env<'a, F> {
             workqueue_set.insert(block);
         }
 
-        while !workqueue.is_empty() {
-            let block = workqueue.pop_front().unwrap();
+        while let Some(block) = workqueue.pop_front() {
             workqueue_set.remove(&block);
             let insns = self.func.block_insns(block);
 


### PR DESCRIPTION
A few refactorings I made while reading through the regalloc2 source. The diff looks larger than it is because of indent changes, so I'd recommend reviewing with space changes turned off.

- Use a while-let instead of checking is_empty and popping
- This conditional should always be true, as we expect the input is in ssa
- Use iter_mut instead of iterating the index
- We don't support multiple defs of the same vreg anymore
- Drain instead of clear
