### PR TITLE
Slightly more efficient vec initialization

### DIFF
--- a/src/postorder.rs
+++ b/src/postorder.rs
@@ -18,8 +18,7 @@ pub fn calculate<'a, SuccFn: Fn(Block) -> &'a [Block]>(
     let mut ret = vec![];
 
     // State: visited-block map, and explicit DFS stack.
-    let mut visited = vec![];
-    visited.resize(num_blocks, false);
+    let mut visited = vec![false; num_blocks];
 
     struct State<'a> {
         block: Block,


### PR DESCRIPTION
This will, at least on x86_64, compile down to simpler, shorter assembly that uses a zeroed allocation instead of a regular allocation, a memset and various `raw_vec` methods.