### PR TITLE
Auto-fix Clippy lints

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -108,7 +108,7 @@ impl CFGInfo {
 
             approx_loop_depth.push(cur_depth);
 
-            while backedge_stack.len() > 0 && backedge_out[block] > 0 {
+            while !backedge_stack.is_empty() && backedge_out[block] > 0 {
                 backedge_out[block] -= 1;
                 *backedge_stack.last_mut().unwrap() -= 1;
                 if *backedge_stack.last().unwrap() == 0 {

--- a/src/index.rs
+++ b/src/index.rs
@@ -46,7 +46,7 @@ macro_rules! define_index {
             }
         }
 
-        impl crate::index::ContainerIndex for $ix {}
+        impl $crate::index::ContainerIndex for $ix {}
     };
 }
 

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -126,7 +126,7 @@ impl AdaptiveMap {
                 }
                 None
             }
-            &Self::Large(ref map) => {
+            Self::Large(map) => {
                 let value = map.get(&key).cloned();
                 value
             }
@@ -139,7 +139,7 @@ impl AdaptiveMap {
                 ref keys,
                 ref values,
             } => AdaptiveMapIter::Small(&keys[0..len as usize], &values[0..len as usize]),
-            &Self::Large(ref map) => AdaptiveMapIter::Large(map.iter()),
+            Self::Large(map) => AdaptiveMapIter::Large(map.iter()),
         }
     }
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -457,7 +457,7 @@ impl<'a, F: Function> Env<'a, F> {
         let old_class = self.vregs[vreg.vreg()].class.replace(vreg.class());
         // We should never observe two different classes for two
         // mentions of a VReg in the source program.
-        debug_assert!(old_class == None || old_class == Some(vreg.class()));
+        debug_assert!(old_class.is_none() || old_class == Some(vreg.class()));
     }
 
     /// Is this vreg actually used in the source program?

--- a/src/ion/dump.rs
+++ b/src/ion/dump.rs
@@ -1,7 +1,7 @@
 //! Debugging output.
 
+use alloc::format;
 use alloc::string::ToString;
-use alloc::{format, vec};
 use alloc::{string::String, vec::Vec};
 
 use super::Env;
@@ -58,7 +58,7 @@ impl<'a, F: Function> Env<'a, F> {
         if self.annotations_enabled {
             self.debug_annotations
                 .entry(progpoint)
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(s);
         }
     }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -385,11 +385,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
 
             for &pred in self.func.block_preds(block) {
-                if self.liveouts[pred.index()].union_with(&live) {
-                    if !workqueue_set.contains(&pred) {
-                        workqueue_set.insert(pred);
-                        workqueue.push_back(pred);
-                    }
+                if self.liveouts[pred.index()].union_with(&live) && !workqueue_set.contains(&pred) {
+                    workqueue_set.insert(pred);
+                    workqueue.push_back(pred);
                 }
             }
 

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -107,15 +107,14 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         // Check for a requirements conflict.
-        if self.bundles[from.index()].cached_stack()
+        if (self.bundles[from.index()].cached_stack()
             || self.bundles[from.index()].cached_fixed()
             || self.bundles[to.index()].cached_stack()
-            || self.bundles[to.index()].cached_fixed()
+            || self.bundles[to.index()].cached_fixed())
+            && self.merge_bundle_requirements(from, to).is_err()
         {
-            if self.merge_bundle_requirements(from, to).is_err() {
-                trace!(" -> conflicting requirements; aborting merge");
-                return false;
-            }
+            trace!(" -> conflicting requirements; aborting merge");
+            return false;
         }
 
         trace!(" -> committing to merge");

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -25,8 +25,8 @@ use crate::{
     Allocation, Block, Edit, Function, FxHashMap, Inst, InstPosition, OperandConstraint,
     OperandKind, OperandPos, PReg, ProgPoint, RegClass, SpillSlot, VReg,
 };
+use alloc::format;
 use alloc::vec::Vec;
-use alloc::{format, vec};
 use core::fmt::Debug;
 use smallvec::{smallvec, SmallVec};
 
@@ -630,7 +630,7 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         // Handle multi-fixed-reg constraints by copying.
-        for fixup in core::mem::replace(&mut self.multi_fixed_reg_fixups, vec![]) {
+        for fixup in core::mem::take(&mut self.multi_fixed_reg_fixups) {
             let from_alloc = self.get_alloc(fixup.pos.inst(), fixup.from_slot as usize);
             let to_alloc = Allocation::reg(PReg::from_index(fixup.to_preg.index()));
             trace!(
@@ -869,7 +869,7 @@ impl<'a, F: Function> Env<'a, F> {
                     if let Some(reg) = self.env.scratch_by_class[regclass as usize] {
                         return Some(Allocation::reg(reg));
                     }
-                    while let Some(preg) = scratch_iter.next() {
+                    for preg in scratch_iter.by_ref() {
                         if !self.pregs[preg.index()]
                             .allocations
                             .btree

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -187,7 +187,7 @@ impl<'a, F: Function> Env<'a, F> {
             }
         }
 
-        if conflicts.len() > 0 {
+        if !conflicts.is_empty() {
             return AllocRegResult::Conflict(conflicts, first_conflict.unwrap());
         }
 
@@ -360,7 +360,7 @@ impl<'a, F: Function> Env<'a, F> {
             trace!("range{}: use {:?}", range.index(), u);
         }
         rangedata.set_uses_spill_weight(w);
-        if rangedata.uses.len() > 0 && rangedata.uses[0].operand.kind() == OperandKind::Def {
+        if !rangedata.uses.is_empty() && rangedata.uses[0].operand.kind() == OperandKind::Def {
             // Note that we *set* the flag here, but we never *clear*
             // it: it may be set by a progmove as well (which does not
             // create an explicit use or def), and we want to preserve
@@ -730,13 +730,13 @@ impl<'a, F: Function> Env<'a, F> {
             }
         }
 
-        if self.bundles[bundle.index()].ranges.len() > 0 {
+        if !self.bundles[bundle.index()].ranges.is_empty() {
             self.recompute_bundle_properties(bundle);
             let prio = self.bundles[bundle.index()].prio;
             self.allocation_queue
                 .insert(bundle, prio as usize, reg_hint);
         }
-        if self.bundles[new_bundle.index()].ranges.len() > 0 {
+        if !self.bundles[new_bundle.index()].ranges.is_empty() {
             self.recompute_bundle_properties(new_bundle);
             let prio = self.bundles[new_bundle.index()].prio;
             self.allocation_queue
@@ -979,7 +979,7 @@ impl<'a, F: Function> Env<'a, F> {
         // Recompute bundle properties for all new bundles and enqueue
         // them.
         for bundle in new_bundles {
-            if self.bundles[bundle.index()].ranges.len() > 0 {
+            if !self.bundles[bundle.index()].ranges.is_empty() {
                 self.recompute_bundle_properties(bundle);
                 let prio = self.bundles[bundle.index()].prio;
                 self.allocation_queue

--- a/src/ion/redundant_moves.rs
+++ b/src/ion/redundant_moves.rs
@@ -30,12 +30,12 @@ impl RedundantMoveEliminator {
         let from_state = self
             .allocs
             .get(&from)
-            .map(|&p| p)
+            .copied()
             .unwrap_or(RedundantMoveState::None);
         let to_state = self
             .allocs
             .get(&to)
-            .map(|&p| p)
+            .copied()
             .unwrap_or(RedundantMoveState::None);
 
         trace!(

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -53,12 +53,12 @@ impl<'a> RegTraversalIter<'a> {
         }
         let hints = [hint_reg, hint2_reg];
         let class = class as u8 as usize;
-        let offset_pref = if env.preferred_regs_by_class[class].len() > 0 {
+        let offset_pref = if !env.preferred_regs_by_class[class].is_empty() {
             offset % env.preferred_regs_by_class[class].len()
         } else {
             0
         };
-        let offset_non_pref = if env.non_preferred_regs_by_class[class].len() > 0 {
+        let offset_non_pref = if !env.non_preferred_regs_by_class[class].is_empty() {
             offset % env.non_preferred_regs_by_class[class].len()
         } else {
             0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,8 +305,7 @@ impl VReg {
 
     #[inline(always)]
     pub const fn vreg(self) -> usize {
-        let vreg = (self.bits >> 1) as usize;
-        vreg
+        (self.bits >> 1) as usize
     }
 
     #[inline(always)]
@@ -723,7 +722,7 @@ impl Operand {
     /// are used to track dataflow.
     #[inline(always)]
     pub fn vreg(self) -> VReg {
-        let vreg_idx = ((self.bits as usize) & VReg::MAX) as usize;
+        let vreg_idx = (self.bits as usize) & VReg::MAX;
         VReg::new(vreg_idx, self.class())
     }
 
@@ -1204,7 +1203,7 @@ impl ProgPoint {
     /// Create a new ProgPoint before or after the given instruction.
     #[inline(always)]
     pub fn new(inst: Inst, pos: InstPosition) -> Self {
-        let bits = ((inst.0 as u32) << 1) | (pos as u8 as u32);
+        let bits = (inst.0 << 1) | (pos as u8 as u32);
         Self { bits }
     }
 

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -115,18 +115,16 @@ pub fn validate_ssa<F: Function>(f: &F, cfginfo: &CFGInfo) -> Result<(), RegAllo
                         }
                     }
                 }
-            } else {
-                if f.is_branch(insn) || f.is_ret(insn) {
-                    trace!("Block terminator found in the middle of a block");
-                    return Err(RegAllocError::BB(block));
-                }
+            } else if f.is_branch(insn) || f.is_ret(insn) {
+                trace!("Block terminator found in the middle of a block");
+                return Err(RegAllocError::BB(block));
             }
         }
     }
 
     // Check that the entry block has no block args: otherwise it is
     // undefined what their value would be.
-    if f.block_params(f.entry_block()).len() > 0 {
+    if !f.block_params(f.entry_block()).is_empty() {
         trace!("Entry block contains block args");
         return Err(RegAllocError::BB(f.entry_block()));
     }


### PR DESCRIPTION
I found no information about the MSRV of this library, so I just told Clippy to use 1.63.0, 5 versions older than the current stable.

This brings down Clippy's warning count from 66 to 25.