### PR TITLE
Initial support for overlapping LiveRanges

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -38,7 +38,7 @@ pub struct CodeRange {
 impl CodeRange {
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.from == self.to
+        self.from >= self.to
     }
     #[inline(always)]
     pub fn contains(&self, other: &Self) -> bool {

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -64,14 +64,6 @@ impl CodeRange {
             to: pos.next(),
         }
     }
-    /// Returns the range covering just one instruction.
-    #[inline(always)]
-    pub fn single_inst(inst: Inst) -> CodeRange {
-        CodeRange {
-            from: ProgPoint::before(inst),
-            to: ProgPoint::before(inst.next()),
-        }
-    }
 
     /// Join two [CodeRange] values together, producing a [CodeRange] that includes both.
     #[inline(always)]
@@ -135,14 +127,10 @@ pub struct LiveRange {
     pub merged_into: LiveRangeIndex,
 }
 
-/// Flags for LiveRanges. The values of these enums are bit patterns, not indices. There are
-/// currently only three bits free in `uses_spill_weight_and_flags` in `LiveRange`, so there is at
-/// most one additional flag that can be added here, with the value `4`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum LiveRangeFlag {
     StartsAtDef = 1,
-    Overlap = 2,
 }
 
 impl LiveRange {
@@ -194,7 +182,6 @@ pub struct Use {
     pub pos: ProgPoint,
     pub slot: u8,
     pub weight: u16,
-    tombstoned: bool,
 }
 
 impl Use {
@@ -206,18 +193,7 @@ impl Use {
             slot,
             // Weight is updated on insertion into LR.
             weight: 0,
-            tombstoned: false,
         }
-    }
-
-    /// Mark this use as tombstoned.
-    pub fn tombstone(&mut self) {
-        self.tombstoned = true;
-    }
-
-    /// Has this use been tombstoned?
-    pub fn is_tombstoned(&self) -> bool {
-        self.tombstoned
     }
 }
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -312,7 +312,7 @@ pub struct SpillSet {
     pub range: CodeRange,
 }
 
-pub(crate) const MAX_SPLITS_PER_SPILLSET: u8 = 10;
+pub(crate) const MAX_SPLITS_PER_SPILLSET: u8 = 2;
 
 #[derive(Clone, Debug)]
 pub struct VRegData {

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -818,6 +818,56 @@ impl<'a, F: Function> Env<'a, F> {
             debug_assert!(range.uses.windows(2).all(|win| win[0].pos <= win[1].pos));
         }
 
+        // Insert safepoint virtual stack uses, if needed.
+        for &vreg in self.func.reftype_vregs() {
+            let vreg = VRegIndex::new(vreg.vreg());
+            let mut inserted = false;
+            let mut safepoint_idx = 0;
+            for range_idx in 0..self.vregs[vreg.index()].ranges.len() {
+                let LiveRangeListEntry { range, index } =
+                    self.vregs[vreg.index()].ranges[range_idx];
+                while safepoint_idx < self.safepoints.len()
+                    && ProgPoint::before(self.safepoints[safepoint_idx]) < range.from
+                {
+                    safepoint_idx += 1;
+                }
+                while safepoint_idx < self.safepoints.len()
+                    && range.contains_point(ProgPoint::before(self.safepoints[safepoint_idx]))
+                {
+                    // Create a virtual use.
+                    let pos = ProgPoint::before(self.safepoints[safepoint_idx]);
+                    let operand = Operand::new(
+                        self.vreg(vreg),
+                        OperandConstraint::Stack,
+                        OperandKind::Use,
+                        OperandPos::Early,
+                    );
+
+                    trace!(
+                        "Safepoint-induced stack use of {:?} at {:?} -> {:?}",
+                        operand,
+                        pos,
+                        index,
+                    );
+
+                    self.insert_use_into_liverange(index, Use::new(operand, pos, SLOT_NONE));
+                    safepoint_idx += 1;
+
+                    inserted = true;
+                }
+
+                if inserted {
+                    self.ranges[index.index()]
+                        .uses
+                        .sort_unstable_by_key(|u| u.pos);
+                }
+
+                if safepoint_idx >= self.safepoints.len() {
+                    break;
+                }
+            }
+        }
+
         self.blockparam_ins.sort_unstable_by_key(|x| x.key());
         self.blockparam_outs.sort_unstable_by_key(|x| x.key());
 
@@ -836,7 +886,7 @@ impl<'a, F: Function> Env<'a, F> {
         // have to split the multiple uses at the same progpoint into
         // different bundles, which breaks invariants related to
         // disjoint ranges and bundles).
-        let mut range_edits = vec![];
+        let mut extra_clobbers: SmallVec<[(PReg, ProgPoint); 8]> = smallvec![];
         for vreg in 0..self.vregs.len() {
             for range_idx in 0..self.vregs[vreg].ranges.len() {
                 let entry = self.vregs[vreg].ranges[range_idx];
@@ -848,7 +898,6 @@ impl<'a, F: Function> Env<'a, F> {
                 );
 
                 // Find groups of uses that occur in at the same program point.
-                let mut tombstoned = false;
                 for uses in self.ranges[range.index()]
                     .uses
                     .linear_group_by_key_mut(|u| u.pos)
@@ -897,6 +946,15 @@ impl<'a, F: Function> Env<'a, F> {
                         continue;
                     }
 
+                    // We pick one constraint (in order: FixedReg, Reg, FixedStack)
+                    // and then rewrite any incompatible constraints to Any.
+                    // This allows register allocation to succeed and we will
+                    // later insert moves to satisfy the rewritten constraints.
+                    let source_slot = if requires_reg {
+                        first_reg_slot.unwrap()
+                    } else {
+                        first_stack_slot.unwrap()
+                    };
                     let mut first_preg = None;
                     for u in uses.iter_mut() {
                         if let OperandConstraint::FixedReg(preg) = u.operand.constraint() {
@@ -921,110 +979,33 @@ impl<'a, F: Function> Env<'a, F> {
                                 continue;
                             }
 
-                            trace!(
-                                " -> overlapping liverange {} at inst{}",
-                                preg,
-                                u.pos.inst().index()
+                            trace!(" -> duplicate; switching to constraint Any");
+                            self.multi_fixed_reg_fixups.push(MultiFixedRegFixup {
+                                pos: u.pos,
+                                from_slot: source_slot,
+                                to_slot: u.slot,
+                                to_preg: preg_idx,
+                                vreg: vreg_idx,
+                                level: FixedRegFixupLevel::Secondary,
+                            });
+                            u.operand = Operand::new(
+                                u.operand.vreg(),
+                                OperandConstraint::Any,
+                                u.operand.kind(),
+                                u.operand.pos(),
                             );
-                            range_edits.push((range_idx, vreg_idx, *u));
-
-                            trace!(" -> tombstoning use");
-                            u.tombstone();
-                            tombstoned = true;
+                            trace!(" -> extra clobber {} at inst{}", preg, u.pos.inst().index());
+                            extra_clobbers.push((preg, u.pos));
                         }
                     }
                 }
 
-                if tombstoned {
-                    // If there are edits to process, there are also tombstoned entries in the uses
-                    // list for this liverange.
-                    self.ranges[range.index()]
-                        .uses
-                        .retain(|u| !u.is_tombstoned());
-                }
-            }
-
-            // If there are edits to perform, rebuild the ranges for `vreg` and insert the edits at
-            // sorted.
-            if !range_edits.is_empty() {
-                let mut iter = range_edits.drain(..).peekable();
-                let old_ranges = core::mem::take(&mut self.vregs[vreg].ranges);
-                for (ix, range) in old_ranges.into_iter().enumerate() {
-                    self.vregs[vreg].ranges.push(range);
-                    while Some(ix) == iter.peek().map(|(range_ix, _, _)| *range_ix) {
-                        let (_, vreg_idx, u) = iter.next().unwrap();
-                        let range = CodeRange::singleton(u.pos);
-                        let lr = self.create_liverange(range);
-                        self.ranges[lr.index()].vreg = vreg_idx;
-                        self.ranges[lr.index()].uses.push(u);
-                        self.ranges[lr.index()]
-                            .set_uses_spill_weight(SpillWeight::from_bits(u.weight));
-
-                        // Avoid merging this live range with the live range that we already know
-                        // we overlap with.
-                        self.ranges[lr.index()].set_flag(LiveRangeFlag::Overlap);
-
-                        self.vregs[vreg]
-                            .ranges
-                            .push(LiveRangeListEntry { range, index: lr });
-                    }
-                }
-            }
-        }
-    }
-
-    /// Insert safepoint virtual stack uses, if needed.
-    pub fn insert_safepoints(&mut self) {
-        trace!("inserting safepoints");
-        for &vreg in self.func.reftype_vregs() {
-            let vreg = VRegIndex::new(vreg.vreg());
-            let mut inserted = false;
-            let mut safepoint_idx = 0;
-            trace!("reffy vreg: {:?}", vreg);
-            for range_idx in 0..self.vregs[vreg.index()].ranges.len() {
-                let LiveRangeListEntry { range, index } =
-                    self.vregs[vreg.index()].ranges[range_idx];
-                trace!("reffy vreg {:?} has range {:?}", vreg, range);
-                while safepoint_idx < self.safepoints.len()
-                    && ProgPoint::before(self.safepoints[safepoint_idx]) < range.from
-                {
-                    safepoint_idx += 1;
-                }
-
-                let mut range_safepoint_idx = safepoint_idx;
-                while range_safepoint_idx < self.safepoints.len()
-                    && range.contains_point(ProgPoint::before(self.safepoints[range_safepoint_idx]))
-                {
-                    // Create a virtual use.
-                    let pos = ProgPoint::before(self.safepoints[range_safepoint_idx]);
-                    let operand = Operand::new(
-                        self.vreg(vreg),
-                        OperandConstraint::Stack,
-                        OperandKind::Use,
-                        OperandPos::Early,
-                    );
-
-                    trace!(
-                        "Safepoint-induced stack use of {:?} at {:?} -> {:?}",
-                        operand,
-                        pos,
-                        index,
-                    );
-
-                    self.insert_use_into_liverange(index, Use::new(operand, pos, SLOT_NONE));
-                    range_safepoint_idx += 1;
-
-                    inserted = true;
-                }
-
-                if inserted {
-                    self.ranges[index.index()]
-                        .uses
-                        .sort_unstable_by_key(|u| u.pos);
-                }
-
-                if safepoint_idx >= self.safepoints.len() {
-                    break;
+                for (clobber, pos) in extra_clobbers.drain(..) {
+                    let range = CodeRange {
+                        from: pos,
+                        to: pos.next(),
+                    };
+                    self.add_liverange_to_preg(range, clobber);
                 }
             }
         }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -309,10 +309,11 @@ impl<'a, F: Function> Env<'a, F> {
     pub fn add_liverange_to_preg(&mut self, range: CodeRange, reg: PReg) {
         trace!("adding liverange to preg: {:?} to {}", range, reg);
         let preg_idx = PRegIndex::new(reg.index());
-        self.pregs[preg_idx.index()]
+        let res = self.pregs[preg_idx.index()]
             .allocations
             .btree
             .insert(LiveRangeKey::from_range(&range), LiveRangeIndex::invalid());
+        debug_assert!(res.is_none());
     }
 
     pub fn is_live_in(&mut self, block: Block, vreg: VRegIndex) -> bool {

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -16,8 +16,7 @@ use super::{
     Env, LiveBundleIndex, LiveRangeIndex, SpillSet, SpillSetIndex, SpillSlotIndex, VRegIndex,
 };
 use crate::{
-    ion::data_structures::{BlockparamOut, LiveRangeFlag},
-    Function, Inst, OperandConstraint, OperandKind, PReg,
+    ion::data_structures::BlockparamOut, Function, Inst, OperandConstraint, OperandKind, PReg,
 };
 use alloc::format;
 use smallvec::smallvec;
@@ -39,6 +38,14 @@ impl<'a, F: Function> Env<'a, F> {
         let to_rc = self.spillsets[self.bundles[to.index()].spillset.index()].class;
         if from_rc != to_rc {
             trace!(" -> mismatching reg classes");
+            return false;
+        }
+
+        // If either bundle is already assigned (due to a pinned vreg), don't merge.
+        if self.bundles[from.index()].allocation.is_some()
+            || self.bundles[to.index()].allocation.is_some()
+        {
+            trace!("one of the bundles is already assigned (pinned)");
             return false;
         }
 
@@ -235,49 +242,16 @@ impl<'a, F: Function> Env<'a, F> {
             let bundle = self.create_bundle();
             let mut range = self.vregs[vreg.index()].ranges.first().unwrap().range;
 
-            // self.bundles[bundle.index()].ranges = self.vregs[vreg.index()].ranges.clone();
+            self.bundles[bundle.index()].ranges = self.vregs[vreg.index()].ranges.clone();
             trace!("vreg v{} gets bundle{}", vreg.index(), bundle.index());
-            for entry_ix in 0..self.vregs[vreg.index()].ranges.len() {
-                let entry = self.vregs[vreg.index()].ranges[entry_ix];
+            for entry in &self.bundles[bundle.index()].ranges {
                 trace!(
                     " -> with LR range{}: {:?}",
                     entry.index.index(),
                     entry.range
                 );
-
-                let lr = entry.index.index();
-                let bundle = if self.ranges[lr].has_flag(LiveRangeFlag::Overlap) {
-                    let bundle = self.create_bundle();
-                    self.bundles[bundle.index()].set_cached_fixed();
-                    self.bundles[bundle.index()].set_cached_fixed_def();
-                    self.bundles[bundle.index()].set_cached_stack();
-
-                    let reg = self.vreg(vreg);
-                    let size = self.func.spillslot_size(reg.class()) as u8;
-                    let ssidx = SpillSetIndex::new(self.spillsets.len());
-                    self.spillsets.push(SpillSet {
-                        slot: SpillSlotIndex::invalid(),
-                        size,
-                        required: false,
-                        class: reg.class(),
-                        reg_hint: PReg::invalid(),
-                        spill_bundle: LiveBundleIndex::invalid(),
-                        splits: 0,
-
-                        // As entry overlaps another and will get its own bundle, the range for the
-                        // spillset is exactly the range of the entry.
-                        range: entry.range,
-                    });
-                    self.bundles[bundle.index()].spillset = ssidx;
-
-                    bundle
-                } else {
-                    range = range.join(entry.range);
-                    bundle
-                };
-
-                self.ranges[lr].bundle = bundle;
-                self.bundles[bundle.index()].ranges.push(entry);
+                range = range.join(entry.range);
+                self.ranges[entry.index.index()].bundle = bundle;
             }
 
             let mut fixed = false;

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -96,6 +96,7 @@ impl<'a, F: Function> Env<'a, F> {
         self.compute_liveness()?;
         self.build_liveranges();
         self.fixup_multi_fixed_vregs();
+        self.insert_safepoints();
         self.merge_vreg_bundles();
         self.queue_bundles();
         if trace_enabled!() {

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -96,7 +96,6 @@ impl<'a, F: Function> Env<'a, F> {
         self.compute_liveness()?;
         self.build_liveranges();
         self.fixup_multi_fixed_vregs();
-        self.insert_safepoints();
         self.merge_vreg_bundles();
         self.queue_bundles();
         if trace_enabled!() {

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -636,12 +636,12 @@ impl<'a, F: Function> Env<'a, F> {
             // Sort the newly added block_param destinations. The key function ignores the vreg,
             // which is why we sort here: we preserve the vreg order automatically, and sort
             // smaller slices of the dests according to their source/destination blocks.
-            block_param_dests[dests_start..].sort_unstable_by_key(|d| d.key());
+            block_param_dests[dests_start..].sort_unstable_by_key(BlockparamDest::key);
 
             if !inter_block_dests.is_empty() {
                 self.stats.halfmoves_count += inter_block_dests.len() * 2;
 
-                inter_block_dests.sort_unstable_by_key(|d| d.key());
+                inter_block_dests.sort_unstable_by_key(InterBlockDest::key);
 
                 let vreg = self.vreg(vreg);
                 trace!("processing inter-block moves for {}", vreg);
@@ -670,7 +670,7 @@ impl<'a, F: Function> Env<'a, F> {
 
             // Sort the sources to mirror the destinations now, ordering by dest vreg/dest
             // block/source block.
-            block_param_sources.sort_unstable_by_key(|h| h.key());
+            block_param_sources.sort_unstable_by_key(BlockparamSource::key);
 
             trace!("processing block-param moves");
             let mut block_param_sources = block_param_sources.into_iter().peekable();

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -672,6 +672,19 @@ impl<'a, F: Function> Env<'a, F> {
             // block/source block.
             block_param_sources.sort_unstable_by_key(BlockparamSource::key);
 
+            // We traverse the `block_param_sources` and `block_param_dests` vectors in parallel,
+            // advancing a pointer into the sources vector as we disocver dests that don't match
+            // it. There are two places that we ensure that the order of those two vectors enables
+            // this traversal: above when we sort `block_param_sources` according to its key; at
+            // the end of the main vreg loop above when we sort a slice of `block_param_dests` by
+            // its key.
+            //
+            // In both cases, the key function will order entries lexicographically according to
+            // (destination vreg, destination block, source block). One implication of this is that
+            // if there are multiple sources available for a destination, we'll always pick the one
+            // with the lowest source vreg. We could potentially improve this by selecting from the
+            // range of possible sources based on some heuristic (prefer registers, for example).
+
             trace!("processing block-param moves");
             let mut block_param_sources = block_param_sources.into_iter().peekable();
             'outer: for dest in block_param_dests {

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -196,10 +196,14 @@ impl<'a, F: Function> Env<'a, F> {
         trace!("  -> bundle {:?} assigned to preg {:?}", bundle, preg);
         self.bundles[bundle.index()].allocation = Allocation::reg(preg);
         for entry in &self.bundles[bundle.index()].ranges {
-            self.pregs[reg.index()]
+            let key = LiveRangeKey::from_range(&entry.range);
+            let res = self.pregs[reg.index()]
                 .allocations
                 .btree
-                .insert(LiveRangeKey::from_range(&entry.range), entry.index);
+                .insert(key, entry.index);
+
+            // We disallow LR overlap within bundles, so this should never be possible.
+            debug_assert!(res.is_none());
         }
 
         AllocRegResult::Allocated(Allocation::reg(preg))

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -784,6 +784,7 @@ impl<'a, F: Function> Env<'a, F> {
         let mut new_lrs: SmallVec<[(VRegIndex, LiveRangeIndex); 16]> = smallvec![];
         let mut new_bundles: SmallVec<[LiveBundleIndex; 16]> = smallvec![];
 
+        let spillset = self.bundles[bundle.index()].spillset;
         let spill = self
             .get_or_create_spill_bundle(bundle, /* create_if_absent = */ true)
             .unwrap();
@@ -799,18 +800,48 @@ impl<'a, F: Function> Env<'a, F> {
         let mut last_inst: Option<Inst> = None;
         let mut last_vreg: Option<VRegIndex> = None;
 
+        let mut spill_uses = UseList::new();
+
         for entry in core::mem::take(&mut self.bundles[bundle.index()].ranges) {
             let lr_from = entry.range.from;
             let lr_to = entry.range.to;
+            let vreg = self.ranges[entry.index.index()].vreg;
 
             removed_lrs.insert(entry.index);
-            let vreg = self.ranges[entry.index.index()].vreg;
             removed_lrs_vregs.insert(vreg);
             trace!(" -> removing old LR {:?} for vreg {:?}", entry.index, vreg);
+
+            let mut spill_range = entry.range;
+            let mut spill_starts_def = false;
 
             let mut last_live_pos = entry.range.from;
             for u in core::mem::take(&mut self.ranges[entry.index.index()].uses) {
                 trace!("   -> use {:?} (last_live_pos {:?})", u, last_live_pos);
+
+                let is_def = u.operand.kind() == OperandKind::Def;
+
+                // If this use has an `any` constraint, eagerly migrate it to the spill range. The
+                // reasoning here is that in the second-chance allocation for the spill bundle,
+                // any-constrained uses will be easy to satisfy. Solving those constraints earlier
+                // could create unnecessary conflicts with existing bundles that need to fit in a
+                // register, more strict requirements, so we delay them eagerly.
+                if u.operand.constraint() == OperandConstraint::Any {
+                    trace!("    -> migrating this any-constrained use to the spill range");
+                    spill_uses.push(u);
+
+                    // Remember if we're moving the def of this vreg into the spill range, so that
+                    // we can set the appropriate flags on it later.
+                    spill_starts_def = spill_starts_def || is_def;
+
+                    continue;
+                }
+
+                // If this is a def of the vreg the entry cares about, make sure that the spill
+                // range starts right before the next instruction so that the value is available.
+                if is_def {
+                    trace!("    -> moving the spill range forward by one");
+                    spill_range.from = ProgPoint::before(u.pos.inst().next());
+                }
 
                 // If we just created a LR for this inst at the last
                 // pos, add this use to the same LR.
@@ -873,7 +904,7 @@ impl<'a, F: Function> Env<'a, F> {
                 // Create a new bundle that contains only this LR.
                 let new_bundle = self.create_bundle();
                 self.ranges[lr.index()].bundle = new_bundle;
-                self.bundles[new_bundle.index()].spillset = self.bundles[bundle.index()].spillset;
+                self.bundles[new_bundle.index()].spillset = spillset;
                 self.bundles[new_bundle.index()]
                     .ranges
                     .push(LiveRangeListEntry {
@@ -882,13 +913,8 @@ impl<'a, F: Function> Env<'a, F> {
                     });
                 new_bundles.push(new_bundle);
 
-                // If this use was a Def, set the StartsAtDef flag for
-                // the new LR. (N.B.: *not* Mod, only Def, because Mod
-                // needs an input. This flag specifically indicates
-                // that the LR does not require the value to be moved
-                // into location at start because it (re)defines the
-                // value.)
-                if u.operand.kind() == OperandKind::Def {
+                // If this use was a Def, set the StartsAtDef flag for the new LR.
+                if is_def {
                     self.ranges[lr.index()].set_flag(LiveRangeFlag::StartsAtDef);
                 }
 
@@ -899,30 +925,6 @@ impl<'a, F: Function> Env<'a, F> {
                     new_bundle
                 );
 
-                // If there was any intervening range in the LR not
-                // covered by the minimal new LR above, add it to the
-                // spillset.
-                if pos > last_live_pos {
-                    let cr = CodeRange {
-                        from: last_live_pos,
-                        to: pos,
-                    };
-                    let spill_lr = self.create_liverange(cr);
-                    self.ranges[spill_lr.index()].vreg = vreg;
-                    self.ranges[spill_lr.index()].bundle = spill;
-                    new_lrs.push((vreg, spill_lr));
-                    self.bundles[spill.index()].ranges.push(LiveRangeListEntry {
-                        range: cr,
-                        index: spill_lr,
-                    });
-                    self.ranges[spill_lr.index()].bundle = spill;
-                    trace!(
-                        "    -> put intervening range {:?} in new LR {:?} in spill bundle {:?}",
-                        cr,
-                        spill_lr,
-                        spill
-                    );
-                }
                 last_live_pos = ProgPoint::before(u.pos.inst().next());
 
                 last_lr = Some(lr);
@@ -931,28 +933,35 @@ impl<'a, F: Function> Env<'a, F> {
                 last_vreg = Some(vreg);
             }
 
-            // If there is space from the last use to the end of the
-            // LR, put that in the spill bundle too.
-            if entry.range.to > last_live_pos {
-                let cr = CodeRange {
-                    from: last_live_pos,
-                    to: entry.range.to,
-                };
-                let spill_lr = self.create_liverange(cr);
+            if !spill_range.is_empty() {
+                // Make one entry in the spill bundle that covers the whole range.
+                // TODO: it might be worth tracking enough state to only create this LR when there is
+                // open space in the original LR.
+                let spill_lr = self.create_liverange(spill_range);
                 self.ranges[spill_lr.index()].vreg = vreg;
                 self.ranges[spill_lr.index()].bundle = spill;
+                self.ranges[spill_lr.index()]
+                    .uses
+                    .extend(spill_uses.drain(..));
                 new_lrs.push((vreg, spill_lr));
+
+                if spill_starts_def {
+                    self.ranges[spill_lr.index()].set_flag(LiveRangeFlag::StartsAtDef);
+                }
+
                 self.bundles[spill.index()].ranges.push(LiveRangeListEntry {
-                    range: cr,
+                    range: spill_range,
                     index: spill_lr,
                 });
                 self.ranges[spill_lr.index()].bundle = spill;
                 trace!(
-                    "    -> put trailing range {:?} in new LR {:?} in spill bundle {:?}",
-                    cr,
+                    "  -> added spill range {:?} in new LR {:?} in spill bundle {:?}",
+                    spill_range,
                     spill_lr,
                     spill
                 );
+            } else {
+                assert!(spill_uses.is_empty());
             }
         }
 
@@ -1002,6 +1011,7 @@ impl<'a, F: Function> Env<'a, F> {
         let req = match self.compute_requirement(bundle) {
             Ok(req) => req,
             Err(conflict) => {
+                trace!("conflict!: {:?}", conflict);
                 // We have to split right away. We'll find a point to
                 // split that would allow at least the first half of the
                 // split to be conflict-free.

--- a/src/ion/spill.rs
+++ b/src/ion/spill.rs
@@ -13,10 +13,10 @@
 //! Spillslot allocation.
 
 use super::{
-    AllocRegResult, Env, LiveRangeKey, LiveRangeSet, PReg, PRegIndex, RegTraversalIter,
-    SpillSetIndex, SpillSlotData, SpillSlotIndex, SpillSlotList,
+    AllocRegResult, Env, LiveRangeKey, PReg, PRegIndex, RegTraversalIter, SpillSetIndex,
+    SpillSlotData, SpillSlotIndex, SpillSlotList,
 };
-use crate::{Allocation, Function, SpillSlot};
+use crate::{ion::data_structures::SpillSetRanges, Allocation, Function, SpillSlot};
 use smallvec::smallvec;
 
 impl<'a, F: Function> Env<'a, F> {
@@ -69,18 +69,12 @@ impl<'a, F: Function> Env<'a, F> {
         spillslot: SpillSlotIndex,
         spillset: SpillSetIndex,
     ) -> bool {
-        for &vreg in &self.spillsets[spillset.index()].vregs {
-            for entry in &self.vregs[vreg.index()].ranges {
-                if self.spillslots[spillslot.index()]
-                    .ranges
-                    .btree
-                    .contains_key(&LiveRangeKey::from_range(&entry.range))
-                {
-                    return false;
-                }
-            }
-        }
-        true
+        !self.spillslots[spillslot.index()]
+            .ranges
+            .btree
+            .contains_key(&LiveRangeKey::from_range(
+                &self.spillsets[spillset.index()].range,
+            ))
     }
 
     pub fn allocate_spillset_to_spillslot(
@@ -90,27 +84,12 @@ impl<'a, F: Function> Env<'a, F> {
     ) {
         self.spillsets[spillset.index()].slot = spillslot;
 
-        for vreg in &self.spillsets[spillset.index()].vregs {
-            trace!(
-                "spillslot {:?} alloc'ed to spillset {:?}: vreg {:?}",
-                spillslot,
-                spillset,
-                vreg,
-            );
-            for entry in &self.vregs[vreg.index()].ranges {
-                trace!(
-                    "spillslot {:?} getting range {:?} from LR {:?} from vreg {:?}",
-                    spillslot,
-                    entry.range,
-                    entry.index,
-                    vreg,
-                );
-                self.spillslots[spillslot.index()]
-                    .ranges
-                    .btree
-                    .insert(LiveRangeKey::from_range(&entry.range), entry.index);
-            }
-        }
+        let res = self.spillslots[spillslot.index()].ranges.btree.insert(
+            LiveRangeKey::from_range(&self.spillsets[spillset.index()].range),
+            spillset,
+        );
+
+        debug_assert!(res.is_none());
     }
 
     pub fn allocate_spillslots(&mut self) {
@@ -162,7 +141,7 @@ impl<'a, F: Function> Env<'a, F> {
                 // Allocate a new spillslot.
                 let spillslot = SpillSlotIndex::new(self.spillslots.len());
                 self.spillslots.push(SpillSlotData {
-                    ranges: LiveRangeSet::new(),
+                    ranges: SpillSetRanges::new(),
                     alloc: Allocation::none(),
                     slots: size as u32,
                 });

--- a/src/ion/stackmap.rs
+++ b/src/ion/stackmap.rs
@@ -51,6 +51,11 @@ impl<'a, F: Function> Env<'a, F> {
             for entry in &self.vregs[vreg.index()].ranges {
                 let range = entry.range;
                 let alloc = self.get_alloc_for_range(entry.index);
+
+                if !alloc.as_stack().is_some() {
+                    continue;
+                }
+
                 trace!(" -> range {:?}: alloc {}", range, alloc);
                 while safepoint_idx < safepoints.len() && safepoints[safepoint_idx] < range.to {
                     if safepoints[safepoint_idx] < range.from {

--- a/src/moves.rs
+++ b/src/moves.rs
@@ -32,7 +32,7 @@ pub struct ParallelMoves<T: Clone + Copy + Default> {
     parallel_moves: MoveVec<T>,
 }
 
-impl<T: Clone + Copy + Default> ParallelMoves<T> {
+impl<T: Clone + Copy + Default + PartialEq> ParallelMoves<T> {
     pub fn new() -> Self {
         Self {
             parallel_moves: smallvec![],
@@ -105,6 +105,7 @@ impl<T: Clone + Copy + Default> ParallelMoves<T> {
         // Sort moves by destination and check that each destination
         // has only one writer.
         self.parallel_moves.sort_by_key(|&(_, dst, _)| dst);
+        self.parallel_moves.dedup();
         if cfg!(debug_assertions) {
             let mut last_dst = None;
             for &(_, dst, _) in &self.parallel_moves {


### PR DESCRIPTION
This PR introduces overlapping live ranges in the handling of conflicting operand constraints, where previously we would handle these as a special case in `fixup_multi_fixed_vregs`.

There a few key changes needed to support overlapping live ranges:

* During move insertion, we need to buffer the previous liverange that we might consider moving from, as multiple liveranges could start at the current instruction. We also use this as an opportunity to try to keep the longest liverange around, preferring the longest source for each intra-block move.
* We no longer search for open stack slots by checking that all live ranges in a spill set would fit in the stack slot's occupied range, as the `LiveRangeKey` type treats all overlapping live ranges as equal. Instead we build a single code range for all of the ranges contained in the spill set, and search for a spill slot that can accommodate that entire range. This change means that we allocate spill slots for the duration of a bundle, instead of for the ranges contained within it, which is a significant change for sparse fragmented bundles.
* We de-duplicate moves during parallel move resolution now, as unrelated liveranges can end up with the same allocation. One situation where this can occur is when an `any` liverange exists in the spill bundle, and a `stack` liverange exists in the main bundle. Both end up in the same stack slot, and as a result we can see redundant moves inserted.

We now take advantage of overlapping liveranges when splitting into minimal bundles: instead of creating liveranges in the spill bundle to cover the holes in liveranges that we're splitting into minimal bundles, we now create a liverange that completely overlaps the original, and eagerly migrate any `any` constrained uses into it.

Additionally, the functionality for inserting safepoints was moved to its own function and called after overlapping ranges are inserted for conflicting operand constraints. This change bulks out the diff quite a bit, but the body of `insert_safepoints` is the same code that previously was run near the end of `build_liveranges`.

## Performance

This PR sees pretty uniform improvements in compile time, and in some cases improvements in the performance of generated code. The bz2 benchmark does see a slight regression in runtime performance, while seeing a pretty substantial improvement in compile time.

Measurements were taken on my local workstation, with one core dedicated to benchmarking as described in [the sightglass documentation](https://github.com/bytecodealliance/sightglass/blob/af695ee0cc093b3376d152d565da27c71a217f65/docs/cpu-isolation.md).

### spidermonkey

```
compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 1228306374.50 ± 214180221.93 (confidence = 99%)

  cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so is 1.02x to 1.02x faster than main.so!

  [63607552165 63838159365.20 64034128812] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [64831683736 65066465739.70 65326878915] main.so

instantiation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  No difference in performance.

  [1123050 1170647.40 1195693] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [1095295 1163948.30 1204192] main.so

execution :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  No difference in performance.

  [2857737455 2877633434.20 2905504365] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [2868002163 2889661824.30 2935436958] main.so
```

### pulldown-cmark

```
compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                               
                                                                
  Δ = 86107311.34 ± 5467308.67 (confidence = 99%)               

  cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so is 1.03x to 1.04x faster than main.so!                                            

  [2572262900 2590690608.58 2618767371] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so                                             
  [2662109567 2676797919.92 2691918238] main.so                 
                                                                                                                                
execution :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                                 
                                                                                                                                
  Δ = 49868.64 ± 46853.01 (confidence = 99%)                    

  cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so is 1.00x to 1.00x faster than main.so!                                            

  [23461002 23625973.16 23889652] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so                                                   
  [23528485 23675841.80 23927040] main.so                       
                                                                                                                                
instantiation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                             
                                                                                                                                
  No difference in performance.                                 

  [502107 823337.30 1084313] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so                                                        
  [499095 855831.38 1251863] main.so  
```

### bz2

```
compilation :: cycles :: benchmarks/bz2/benchmark.wasm

  Δ = 149959411.00 ± 7008550.23 (confidence = 99%)

  cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so is 1.13x to 1.14x faster than main.so!

  [1107453460 1126820291.56 1143741262] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [1258246635 1276779702.56 1292666488] main.so

execution :: cycles :: benchmarks/bz2/benchmark.wasm

  Δ = 1572466.02 ± 688757.67 (confidence = 99%)

  main.so is 1.00x to 1.01x faster than cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so!

  [305870740 307067830.34 311638170] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [302983030 305495364.32 310462500] main.so

instantiation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [344452 385765.94 447515] cd3feb5afeb90b5e20f8e54aa08e80c38f21f3ff.so
  [337942 384964.30 426030] main.so
```

## Stats

The RA2 statistics change in interesting ways as an effect of this PR. I've included the stat field diffs below, to give more context to the performance numbers above. These were generated by using the `--emit-clif` option with `wasmtime compile` to emit clif files for each function in the benchmark, then modifying `clif-util` to print out the RA2 stats after register allocation had completed. The output from `main` and this branch were then compared and diffed, and the resulting changes sorted so that only the  extremes are reported below.

### spidermonkey

```
edits_count:
  [-281,335]
evict_bundle_count:
  [-32,3]
evict_bundle_event:
  [-31,3]
final_bundle_count:
  [-1196,439]
final_liverange_count:
  [-2374,752]
halfmoves_count:
  [-2790,490]
process_bundle_count:
  [-1212,423]
process_bundle_reg_probes_any:
  [-4337,111]
process_bundle_reg_probe_start_any:
  [-603,440]
process_bundle_reg_success_any:
  [-440,454]
spill_bundle_count:
  [-7,2]
spill_bundle_reg_probes:
  [-7,2]
spill_bundle_reg_success:
  [-12,16]
splits:
  [-140,2]
```

## pulldown-cmark

```
edits_count:
  [-230,175]
evict_bundle_count:
  [-36,-1]
evict_bundle_event:
  [-36,-1]
final_bundle_count:
  [-25,203]
final_liverange_count:
  [-510,293]
halfmoves_count:
  [-418,452]
process_bundle_count:
  [-33,66]
process_bundle_reg_probes_any:
  [-1691,461]
process_bundle_reg_probe_start_any:
  [-24,131]
process_bundle_reg_success_any:
  [-8,241]
spill_bundle_count:
  [-4,2]
spill_bundle_reg_probes:
  [-4,2]
spill_bundle_reg_success:
  [-4,6]
splits:
  [-126,-1]
```

## bz2

```
edits_count:
  [-27,1020]
evict_bundle_count:
  [-30,1]
evict_bundle_event:
  [-26,1]
final_bundle_count:
  [-3,1535]
final_liverange_count:
  [-314,1436]
halfmoves_count:
  [-336,262]
process_bundle_count:
  [-34,1418]
process_bundle_reg_probes_any:
  [-1566,445]
process_bundle_reg_probe_start_any:
  [-38,1402]
process_bundle_reg_success_any:
  [-2,1509]
spill_bundle_count:
  [-4,1]
spill_bundle_reg_probes:
  [-4,1]
spill_bundle_reg_success:
  [-2,2]
splits:
  [-96,-1]
```