### PR TITLE
Bump to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc2"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
Make a new release for RA2. This release bumps the major number, as there have been a number of breaking changes since 0.6.1.
