### PR TITLE
Add a third register class

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -146,7 +146,7 @@ impl Function for Func {
     fn spillslot_size(&self, regclass: RegClass) -> usize {
         match regclass {
             RegClass::Int => 1,
-            RegClass::Float => 2,
+            RegClass::Float | RegClass::Vector => 2,
         }
     }
 }
@@ -659,9 +659,9 @@ pub fn machine_env() -> MachineEnv {
     fn regs(r: core::ops::Range<usize>) -> Vec<PReg> {
         r.map(|i| PReg::new(i, RegClass::Int)).collect()
     }
-    let preferred_regs_by_class: [Vec<PReg>; 2] = [regs(0..24), vec![]];
-    let non_preferred_regs_by_class: [Vec<PReg>; 2] = [regs(24..32), vec![]];
-    let scratch_by_class: [Option<PReg>; 2] = [None, None];
+    let preferred_regs_by_class: [Vec<PReg>; 3] = [regs(0..24), vec![], vec![]];
+    let non_preferred_regs_by_class: [Vec<PReg>; 3] = [regs(24..32), vec![], vec![]];
+    let scratch_by_class: [Option<PReg>; 3] = [None, None, None];
     let fixed_stack_slots = regs(32..63);
     // Register 63 is reserved for use as a fixed non-allocatable register.
     MachineEnv {

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -404,8 +404,8 @@ pub struct Env<'a, F: Function> {
     pub spillslots: Vec<SpillSlotData>,
     pub slots_by_size: Vec<SpillSlotList>,
 
-    pub extra_spillslots_by_class: [SmallVec<[Allocation; 2]>; 2],
-    pub preferred_victim_by_class: [PReg; 2],
+    pub extra_spillslots_by_class: [SmallVec<[Allocation; 2]>; 3],
+    pub preferred_victim_by_class: [PReg; 3],
 
     // When multiple fixed-register constraints are present on a
     // single VReg at a single program point (this can happen for,

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -70,8 +70,8 @@ impl<'a, F: Function> Env<'a, F> {
             slots_by_size: vec![],
             allocated_bundle_count: 0,
 
-            extra_spillslots_by_class: [smallvec![], smallvec![]],
-            preferred_victim_by_class: [PReg::invalid(), PReg::invalid()],
+            extra_spillslots_by_class: [smallvec![], smallvec![], smallvec![]],
+            preferred_victim_by_class: [PReg::invalid(), PReg::invalid(), PReg::invalid()],
 
             multi_fixed_reg_fixups: vec![],
             inserted_moves: vec![],


### PR DESCRIPTION
👋 Hey,

For machines with completely separate vector registers it is useful to have a separate third register class. It looks like we now have encoding space to support that.

I've run all 5 fuzzers for about a couple of hours, and nothing showed up.

Fixes: #47 