### PR TITLE
Separate vectors for each priority level

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -434,7 +434,7 @@ pub struct Env<'a, F: Function> {
     // was to the approprate PReg.
     pub multi_fixed_reg_fixups: Vec<MultiFixedRegFixup>,
 
-    pub inserted_moves: Vec<InsertedMove>,
+    pub inserted_moves: [Vec<InsertedMove>; InsertMovePrio::Count as usize],
 
     // Output:
     pub edits: Vec<(PosWithPrio, Edit)>,
@@ -636,13 +636,14 @@ impl LiveRangeSet {
 
 #[derive(Clone, Debug)]
 pub struct InsertedMove {
-    pub pos_prio: PosWithPrio,
+    pub pos: ProgPoint,
     pub from_alloc: Allocation,
     pub to_alloc: Allocation,
     pub to_vreg: VReg,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
 pub enum InsertMovePrio {
     InEdgeMoves,
     Regular,
@@ -650,6 +651,22 @@ pub enum InsertMovePrio {
     MultiFixedRegSecondary,
     ReusedInput,
     OutEdgeMoves,
+
+    /// The number of priorities, used to determine the length of the Env::inserted_moves array.
+    Count,
+}
+
+impl InsertMovePrio {
+    pub fn all() -> &'static [InsertMovePrio] {
+        &[
+            InsertMovePrio::InEdgeMoves,
+            InsertMovePrio::Regular,
+            InsertMovePrio::MultiFixedRegInitial,
+            InsertMovePrio::MultiFixedRegSecondary,
+            InsertMovePrio::ReusedInput,
+            InsertMovePrio::OutEdgeMoves,
+        ]
+    }
 }
 
 /// The fields in this struct are reversed in sort order so that the entire

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -642,6 +642,10 @@ pub struct InsertedMove {
     pub to_vreg: VReg,
 }
 
+/// Move priority levels, for resolving move dependency order.
+///
+/// NOTE: new priority values should be added before `Count`, and `InsertMovePrio::all` should be
+/// updated to include the new priority.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum InsertMovePrio {

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -74,7 +74,7 @@ impl<'a, F: Function> Env<'a, F> {
             preferred_victim_by_class: [PReg::invalid(), PReg::invalid(), PReg::invalid()],
 
             multi_fixed_reg_fixups: vec![],
-            inserted_moves: vec![],
+            inserted_moves: [vec![], vec![], vec![], vec![], vec![], vec![]],
             edits: Vec::with_capacity(n),
             allocs: Vec::with_capacity(4 * n),
             inst_alloc_offsets: vec![],


### PR DESCRIPTION
Instead of storing priority in each entry in `inserted_moves`, keep one vector for each priority level. This saves us four bytes per `inserted_moves` entry, and requires only that we sort on the program point of the moves, not the pair of program point and priority.

Profiling with both sightglass and hyperfine show that there is a very small improvement in compile time for benchmarks like `pulldown-cmark` and `bz2`, with larger benchmarks like `spidermonkey` showing the same performance. One downside is that the redundant move eliminator is less effective, as it's no longer working across priority levels. This comes up in the bz2 benchmark which sees a slight regression in runtime performance, due to excessive writes back to the stack of values that have spilled but are used in moves at different priority levels.

One option for tackling the unnecessary moves would be to sort each vector and then walk them in parallel, allowing the redundant move eliminator to see a more consistent state of the world when resolving moves. This would also allow us to avoid the final sort of edits, as we could construct the correct order up front.

Another option for managing the redundant moves introduced here would be to wait for #122 to land, and instead work towards removing the redundant move eliminator. Removing that part of move resolution will lead to an overall improvement 
in compile-time performance, and would unlock refactorings like this PR.

The diff is considerably easier to read with white space turned off, as the main loop of `resolve_inserted_moves` was indented by one level.
