### PR TITLE
Refactor inserted move handling

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -434,8 +434,6 @@ pub struct Env<'a, F: Function> {
     // was to the approprate PReg.
     pub multi_fixed_reg_fixups: Vec<MultiFixedRegFixup>,
 
-    pub inserted_moves: Vec<InsertedMove>,
-
     // Output:
     pub edits: Vec<(PosWithPrio, Edit)>,
     pub allocs: Vec<Allocation>,
@@ -650,6 +648,46 @@ pub enum InsertMovePrio {
     MultiFixedRegSecondary,
     ReusedInput,
     OutEdgeMoves,
+}
+
+#[derive(Debug, Default)]
+pub struct InsertedMoves {
+    pub moves: Vec<InsertedMove>,
+}
+
+impl InsertedMoves {
+    pub fn push(
+        &mut self,
+        pos: ProgPoint,
+        prio: InsertMovePrio,
+        from_alloc: Allocation,
+        to_alloc: Allocation,
+        to_vreg: VReg,
+    ) {
+        trace!(
+            "insert_move: pos {:?} prio {:?} from_alloc {:?} to_alloc {:?} to_vreg {:?}",
+            pos,
+            prio,
+            from_alloc,
+            to_alloc,
+            to_vreg
+        );
+        if let Some(from) = from_alloc.as_reg() {
+            debug_assert_eq!(from.class(), to_vreg.class());
+        }
+        if let Some(to) = to_alloc.as_reg() {
+            debug_assert_eq!(to.class(), to_vreg.class());
+        }
+        self.moves.push(InsertedMove {
+            pos_prio: PosWithPrio {
+                pos,
+                prio: prio as u32,
+            },
+            from_alloc,
+            to_alloc,
+            to_vreg,
+        });
+    }
 }
 
 /// The fields in this struct are reversed in sort order so that the entire

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -672,6 +672,10 @@ impl InsertedMoves {
             to_alloc,
             to_vreg
         );
+        if from_alloc == to_alloc {
+            trace!(" -> skipping move with same source and  dest");
+            return;
+        }
         if let Some(from) = from_alloc.as_reg() {
             debug_assert_eq!(from.class(), to_vreg.class());
         }

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -74,7 +74,6 @@ impl<'a, F: Function> Env<'a, F> {
             preferred_victim_by_class: [PReg::invalid(), PReg::invalid(), PReg::invalid()],
 
             multi_fixed_reg_fixups: vec![],
-            inserted_moves: vec![],
             edits: Vec::with_capacity(n),
             allocs: Vec::with_capacity(4 * n),
             inst_alloc_offsets: vec![],
@@ -108,8 +107,8 @@ impl<'a, F: Function> Env<'a, F> {
         self.process_bundles()?;
         self.try_allocating_regs_for_spilled_bundles();
         self.allocate_spillslots();
-        self.apply_allocations_and_insert_moves();
-        self.resolve_inserted_moves();
+        let moves = self.apply_allocations_and_insert_moves();
+        self.resolve_inserted_moves(moves);
         self.compute_stackmaps();
         Ok(())
     }

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -897,9 +897,6 @@ impl<'a, F: Function> Env<'a, F> {
             let mut vec_moves: SmallVec<[InsertedMove; 8]> = smallvec![];
 
             for m in moves {
-                if m.from_alloc == m.to_alloc {
-                    continue;
-                }
                 match m.to_vreg.class() {
                     RegClass::Int => {
                         int_moves.push(m.clone());


### PR DESCRIPTION
Move the vector of inserted moves out of the `Env` struct, and instead return it from `Env::apply_allocations_and_insert_moves`. `Env::resolve_inserted_moves` now consumes that vector directly, instead of mutating the `Env` state.

Additionally, we now skip recording moves where the source and dest allocations are the same.

## Performance

This PR shows a small improvement in performance, with 1-2% improvements in compile time on bz2 and pulldown-cmark. There's some noise in the execution benchmarks, so I'm going to investigate the assembly diff to confirm that it's just noise.

### bz2

```
compilation :: cycles :: benchmarks/bz2/benchmark.wasm                                                                         

  Δ = 21747167.72 ± 7037094.92 (confidence = 99%)                                                                              
                                                               
  b2cd8396a93042f95fe4690433d5d517fbb25e14.so is 1.01x to 1.03x faster than main.so!                                           
                                                                                                                               
  [1089812893 1108670245.66 1126062200] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                            
  [1110378665 1130417413.38 1147299605] main.so

execution :: cycles :: benchmarks/bz2/benchmark.wasm                                                                           

  Δ = 5439101.72 ± 637870.15 (confidence = 99%)                                                                                
                                                               
  b2cd8396a93042f95fe4690433d5d517fbb25e14.so is 1.02x to 1.02x faster than main.so!                                           
                                                                                                                               
  [303443153 305626527.00 308190970] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                               
  [308902588 311065628.72 312549220] main.so

instantiation :: cycles :: benchmarks/bz2/benchmark.wasm                                                                       
                                                               
  No difference in performance.                                                                                                
                                                                                                                               
  [341287 391382.64 433837] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                                        
  [322435 387237.26 448820] main.so  
```

### pulldown-cmark

```
compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                              
                               
  Δ = 41893730.46 ± 5574767.63 (confidence = 99%)              

  b2cd8396a93042f95fe4690433d5d517fbb25e14.so is 1.01x to 1.02x faster than main.so!                                           

  [2536627786 2552209773.28 2571675317] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                            
  [2577842209 2594103503.74 2613059007] main.so                
                                                                                                                               
execution :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                                
                                                                                                                               
  Δ = 136326.50 ± 49684.28 (confidence = 99%)  

  main.so is 1.00x to 1.01x faster than b2cd8396a93042f95fe4690433d5d517fbb25e14.so!                                           

  [23523790 23661912.38 23969472] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                                  
  [23350740 23525585.88 23831462] main.so                      
                                                                                                                               
instantiation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm                                                            
                                                                                                                               
  No difference in performance.             

  [515718 800595.60 1082963] b2cd8396a93042f95fe4690433d5d517fbb25e14.so                                                       
  [487588 795883.70 1161148] main.so  
```