### PR TITLE
Handle dedicated scratch registers in the redundant move eliminator

### DIFF
--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -796,6 +796,13 @@ impl<'a, F: Function> Env<'a, F> {
                 for reg in this.func.inst_clobbers(inst) {
                     redundant_moves.clear_alloc(Allocation::reg(reg));
                 }
+                // The dedicated scratch registers may be clobbered by any
+                // instruction.
+                for reg in this.env.scratch_by_class {
+                    if let Some(reg) = reg {
+                        redundant_moves.clear_alloc(Allocation::reg(reg));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When a dedicated scratch register is provided by the environment, the redundant move eliminator needs to assume that this register can be clobbered by any instruction.

This register can't be specified as a clobber because it is also used by jump instructions which cannot have operands.