### PR TITLE
Remove the merged_into field of LiveRangeData

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -123,8 +123,6 @@ pub struct LiveRange {
     pub uses_spill_weight_and_flags: u32,
 
     pub uses: UseList,
-
-    pub merged_into: LiveRangeIndex,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -175,10 +175,7 @@ impl<'a, F: Function> Env<'a, F> {
             vreg: VRegIndex::invalid(),
             bundle: LiveBundleIndex::invalid(),
             uses_spill_weight_and_flags: 0,
-
             uses: smallvec![],
-
-            merged_into: LiveRangeIndex::invalid(),
         });
 
         LiveRangeIndex::new(idx)

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -12,9 +12,7 @@
 
 //! Bundle merging.
 
-use super::{
-    Env, LiveBundleIndex, LiveRangeIndex, SpillSet, SpillSetIndex, SpillSlotIndex, VRegIndex,
-};
+use super::{Env, LiveBundleIndex, SpillSet, SpillSetIndex, SpillSlotIndex, VRegIndex};
 use crate::{
     ion::data_structures::BlockparamOut, Function, Inst, OperandConstraint, OperandKind, PReg,
 };
@@ -350,15 +348,6 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         trace!("done merging bundles");
-    }
-
-    pub fn resolve_merged_lr(&self, mut lr: LiveRangeIndex) -> LiveRangeIndex {
-        let mut iter = 0;
-        while iter < 100 && self.ranges[lr.index()].merged_into.is_valid() {
-            lr = self.ranges[lr.index()].merged_into;
-            iter += 1;
-        }
-        lr
     }
 
     pub fn compute_bundle_prio(&self, bundle: LiveBundleIndex) -> u32 {


### PR DESCRIPTION
This field was never written to after initialization, and the only function that looked at its value was never called.
