### PR TITLE
Move edits out of Env

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -714,6 +714,11 @@ impl Edits {
         self.edits.iter()
     }
 
+    #[inline(always)]
+    pub fn into_edits(self) -> impl Iterator<Item = (ProgPoint, Edit)> {
+        self.edits.into_iter().map(|(pos, edit)| (pos.pos, edit))
+    }
+
     pub fn add(&mut self, pos_prio: PosWithPrio, from: Allocation, to: Allocation) {
         if from != to {
             if from.is_reg() && to.is_reg() {

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -693,7 +693,7 @@ impl InsertedMoves {
 
 #[derive(Clone, Debug)]
 pub struct Edits {
-    pub edits: Vec<(PosWithPrio, Edit)>,
+    edits: Vec<(PosWithPrio, Edit)>,
 }
 
 impl Edits {
@@ -717,6 +717,13 @@ impl Edits {
     #[inline(always)]
     pub fn into_edits(self) -> impl Iterator<Item = (ProgPoint, Edit)> {
         self.edits.into_iter().map(|(pos, edit)| (pos.pos, edit))
+    }
+
+    /// Sort edits by the combination of their program position and priority. This is a stable sort
+    /// to preserve the order of the moves the parallel move resolver inserts.
+    #[inline(always)]
+    pub fn sort(&mut self) {
+        self.edits.sort_by_key(|&(pos_prio, _)| pos_prio.key());
     }
 
     pub fn add(&mut self, pos_prio: PosWithPrio, from: Allocation, to: Allocation) {

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -433,7 +433,6 @@ pub struct Env<'a, F: Function> {
     pub multi_fixed_reg_fixups: Vec<MultiFixedRegFixup>,
 
     // Output:
-    pub edits: Vec<(PosWithPrio, Edit)>,
     pub allocs: Vec<Allocation>,
     pub inst_alloc_offsets: Vec<u32>,
     pub num_spillslots: u32,
@@ -689,6 +688,39 @@ impl InsertedMoves {
             to_alloc,
             to_vreg,
         });
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Edits {
+    pub edits: Vec<(PosWithPrio, Edit)>,
+}
+
+impl Edits {
+    #[inline(always)]
+    pub fn with_capacity(n: usize) -> Self {
+        Self {
+            edits: Vec::with_capacity(n),
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.edits.len()
+    }
+
+    #[inline(always)]
+    pub fn iter(&self) -> impl Iterator<Item = &(PosWithPrio, Edit)> {
+        self.edits.iter()
+    }
+
+    pub fn add(&mut self, pos_prio: PosWithPrio, from: Allocation, to: Allocation) {
+        if from != to {
+            if from.is_reg() && to.is_reg() {
+                debug_assert_eq!(from.as_reg().unwrap().class(), to.as_reg().unwrap().class());
+            }
+            self.edits.push((pos_prio, Edit::Move { from, to }));
+        }
     }
 }
 

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -135,11 +135,7 @@ pub fn run<F: Function>(
     }
 
     Ok(Output {
-        edits: edits
-            .edits
-            .into_iter()
-            .map(|(pos_prio, edit)| (pos_prio.pos, edit))
-            .collect(),
+        edits: edits.into_edits().collect(),
         allocs: env.allocs,
         inst_alloc_offsets: env.inst_alloc_offsets,
         num_spillslots: env.num_spillslots as usize,

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -995,7 +995,7 @@ impl<'a, F: Function> Env<'a, F> {
         // be a stable sort! We have to keep the order produced by the
         // parallel-move resolver for all moves within a single sort
         // key.
-        edits.edits.sort_by_key(|&(pos_prio, _)| pos_prio.key());
+        edits.sort();
         self.stats.edits_count = edits.len();
 
         // Add debug annotations.

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -17,8 +17,8 @@ use super::{
     RedundantMoveEliminator, VRegIndex, SLOT_NONE,
 };
 use crate::ion::data_structures::{
-    u64_key, BlockparamIn, BlockparamOut, CodeRange, FixedRegFixupLevel, LiveRangeKey,
-    LiveRangeListEntry, PosWithPrio,
+    u64_key, BlockparamIn, BlockparamOut, CodeRange, Edits, FixedRegFixupLevel, LiveRangeKey,
+    LiveRangeListEntry,
 };
 use crate::ion::reg_traversal::RegTraversalIter;
 use crate::moves::{MoveAndScratchResolver, ParallelMoves};
@@ -772,7 +772,7 @@ impl<'a, F: Function> Env<'a, F> {
         inserted_moves
     }
 
-    pub fn resolve_inserted_moves(&mut self, mut inserted_moves: InsertedMoves) {
+    pub fn resolve_inserted_moves(&mut self, mut inserted_moves: InsertedMoves) -> Edits {
         // For each program point, gather all moves together. Then
         // resolve (see cases below).
         let mut i = 0;
@@ -839,6 +839,7 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         let mut last_pos = ProgPoint::before(Inst::new(0));
+        let mut edits = Edits::with_capacity(self.func.num_insts());
 
         while i < inserted_moves.moves.len() {
             let start = i;
@@ -982,7 +983,7 @@ impl<'a, F: Function> Env<'a, F> {
                     trace!("  resolved: {} -> {} ({:?})", src, dst, to_vreg);
                     let action = redundant_moves.process_move(src, dst, to_vreg);
                     if !action.elide {
-                        self.add_move_edit(pos_prio, src, dst);
+                        edits.add(pos_prio, src, dst);
                     } else {
                         trace!("    -> redundant move elided");
                     }
@@ -994,13 +995,12 @@ impl<'a, F: Function> Env<'a, F> {
         // be a stable sort! We have to keep the order produced by the
         // parallel-move resolver for all moves within a single sort
         // key.
-        self.edits.sort_by_key(|&(pos_prio, _)| pos_prio.key());
-        self.stats.edits_count = self.edits.len();
+        edits.edits.sort_by_key(|&(pos_prio, _)| pos_prio.key());
+        self.stats.edits_count = edits.len();
 
         // Add debug annotations.
         if self.annotations_enabled {
-            for i in 0..self.edits.len() {
-                let &(pos_prio, ref edit) = &self.edits[i];
+            for &(pos_prio, ref edit) in edits.iter() {
                 match edit {
                     &Edit::Move { from, to } => {
                         self.annotate(pos_prio.pos, format!("move {} -> {}", from, to));
@@ -1008,14 +1008,7 @@ impl<'a, F: Function> Env<'a, F> {
                 }
             }
         }
-    }
 
-    pub fn add_move_edit(&mut self, pos_prio: PosWithPrio, from: Allocation, to: Allocation) {
-        if from != to {
-            if from.is_reg() && to.is_reg() {
-                debug_assert_eq!(from.as_reg().unwrap().class(), to.as_reg().unwrap().class());
-            }
-            self.edits.push((pos_prio, Edit::Move { from, to }));
-        }
+        edits
     }
 }


### PR DESCRIPTION
Return move edits from `resolve_inserted_moves` instead of eagerly allocating that vector in `Env`.
