### PR TITLE
Allow all allocatable registers to be live

### DIFF
--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -1233,7 +1233,7 @@ impl<'a, F: Function> Env<'a, F> {
                         fixed_assigned,
                         min_bundles_assigned
                     );
-                    if min_bundles_assigned + fixed_assigned >= total_regs {
+                    if min_bundles_assigned + fixed_assigned > total_regs {
                         return Err(RegAllocError::TooManyLiveRegs);
                     }
                 }


### PR DESCRIPTION
This error case seems too restrictive, as it won't allow all allocatable registers to be live at once. Instead, restrict the error case to be when we have a strictly greater number of live assignments than we do allocatable registers.
