### PR TITLE
Handle under-constrained uses when all registers are clobbered

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -18,7 +18,7 @@ use crate::index::ContainerComparator;
 use crate::indexset::IndexSet;
 use crate::{
     define_index, Allocation, Block, Edit, Function, FxHashSet, Inst, MachineEnv, Operand, PReg,
-    ProgPoint, RegClass, VReg,
+    PRegSet, ProgPoint, RegClass, VReg,
 };
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -450,6 +450,9 @@ pub struct Env<'a, F: Function> {
     pub func: &'a F,
     pub env: &'a MachineEnv,
     pub cfginfo: CFGInfo,
+
+    pub pregs_by_class: [PRegSet; 3],
+
     pub liveins: Vec<IndexSet>,
     pub liveouts: Vec<IndexSet>,
     pub blockparam_outs: Vec<BlockparamOut>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,11 @@ impl PRegSet {
         Self { bits: [0; 2] }
     }
 
+    /// True when this set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.bits[0] == 0 && self.bits[1] == 0
+    }
+
     /// Returns whether the given register is part of the set.
     pub fn contains(&self, reg: PReg) -> bool {
         debug_assert!(reg.index() < 256);
@@ -229,6 +234,12 @@ impl PRegSet {
         let bit = reg.index() & 127;
         let index = reg.index() >> 7;
         self.bits[index] &= !(1u128 << bit);
+    }
+
+    /// Remove all registers that occur in `other`.
+    pub fn remove_all(&mut self, other: PRegSet) {
+        self.bits[0] &= !other.bits[0];
+        self.bits[1] &= !other.bits[1];
     }
 
     /// Add all of the registers in one set to this one, mutating in


### PR DESCRIPTION
As reported in #145, under-constrained register uses when an instruction clobbers all registers can lead to the `TooManyLiveRegs` error being raised, despite the problem being resolvable by spilling.

This PR addresses the problem with a bit of a hack: rewriting the `OperandConstraint::Reg` uses in this situation to fixed register constraints, where the physical register chosen is known to not conflict with other uses in the instruction. This allows us to reuse the existing logic present when resolving clobbered fixed register constraints, though the solution feels bad.

I think that a better solution would be to emit virtual stack uses when this situation is detected instead, to force the value to live on the stack for the duration of the instruction. However, this exercises an [unhandled case in `fixup_multi_fixed_vregs`](https://github.com/bytecodealliance/regalloc2/blob/62333e9833a6ed78fb6cba7addca37e4cedc1fcb/src/ion/liveranges.rs#L884-L886): values living in registers and the stack at the same time. I think this could be overcome by reviving parts of the original branch to support overlaps by generating overlapping liveranges for the values to live on the stack. However it's unclear to me if this will resolve the original problem as the problematic liveranges will still be split on instruction boundaries, and will still conflict with the preg liveranges inserted for the clobbers.