### PR TITLE
Avoid generating the state in the check if logging is disabled

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1013,6 +1013,9 @@ impl<'a, F: Function> Checker<'a, F> {
 
         trace!("=== CHECKER RESULT ===");
         fn print_state(state: &CheckerState) {
+            if !trace_enabled!() {
+                return;
+            }
             if let CheckerState::Allocations(allocs) = state {
                 let mut s = vec![];
                 for (alloc, state) in allocs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ macro_rules! trace {
 
 macro_rules! trace_enabled {
     () => {
-        cfg!(feature = "trace-log")
+        cfg!(feature = "trace-log") && ::log::log_enabled!(::log::Level::Trace)
     };
 }
 


### PR DESCRIPTION
This significantly improves the performance of the checker when trace logging is not enabled.