### PR TITLE
Run the fuzzer with all register classes

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -300,7 +300,6 @@ pub struct SpillSet {
     pub class: RegClass,
     pub spill_bundle: LiveBundleIndex,
     pub required: bool,
-    pub size: u8,
     pub splits: u8,
 
     /// The aggregate [`CodeRange`] of all involved [`LiveRange`]s. The effect of this abstraction
@@ -466,7 +465,7 @@ pub struct Env<'a, F: Function> {
 
     pub spilled_bundles: Vec<LiveBundleIndex>,
     pub spillslots: Vec<SpillSlotData>,
-    pub slots_by_size: Vec<SpillSlotList>,
+    pub slots_by_class: [SpillSlotList; 3],
 
     pub extra_spillslots_by_class: [SmallVec<[Allocation; 2]>; 3],
     pub preferred_victim_by_class: [PReg; 3],
@@ -554,6 +553,13 @@ pub struct SpillSlotList {
 }
 
 impl SpillSlotList {
+    pub fn new() -> Self {
+        SpillSlotList {
+            slots: smallvec![],
+            probe_start: 0,
+        }
+    }
+
     /// Get the next spillslot index in probing order, wrapping around
     /// at the end of the slots list.
     pub(crate) fn next_index(&self, index: usize) -> usize {

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -277,10 +277,8 @@ impl<'a, F: Function> Env<'a, F> {
 
             // Create a spillslot for this bundle.
             let reg = self.vreg(vreg);
-            let size = self.func.spillslot_size(reg.class()) as u8;
             let ssidx = self.spillsets.push(SpillSet {
                 slot: SpillSlotIndex::invalid(),
-                size,
                 required: false,
                 class: reg.class(),
                 reg_hint: PReg::invalid(),

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -67,7 +67,11 @@ impl<'a, F: Function> Env<'a, F> {
             safepoints_per_vreg: HashMap::new(),
             spilled_bundles: vec![],
             spillslots: vec![],
-            slots_by_size: vec![],
+            slots_by_class: [
+                SpillSlotList::new(),
+                SpillSlotList::new(),
+                SpillSlotList::new(),
+            ],
             allocated_bundle_count: 0,
 
             extra_spillslots_by_class: [smallvec![], smallvec![], smallvec![]],


### PR DESCRIPTION
This quickly triggers a fuzzbug when two classes have the same spillslot size. It turns out that this is caused by the parallel move resolver not supporting cross-class moves, which can happen if the parallel involves a spillslot used by different classes before/after the move.