### PR TITLE
Version bump to 0.9.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This pulls in a fix for a stackslot confusion bug (among stack slots of the same size) from #152. The bug is reachable only if the embedder has the same stackslot size for different classes, and could result in sharing of a stackslot and thus moves between values of different class (which would likely cause panics in an embedder). This is reachable from RISC-V in Cranelift.