### PR TITLE
Simplify parallel-moves state machine

### DIFF
--- a/src/moves.rs
+++ b/src/moves.rs
@@ -120,110 +120,105 @@ impl<T: Clone + Copy + Default + PartialEq> ParallelMoves<T> {
         // come before. Any given move must come before a move that
         // overwrites its destination; we have moves sorted by dest
         // above so we can efficiently find such a move, if any.
-        let mut must_come_before: SmallVec<[Option<usize>; 16]> =
-            smallvec![None; self.parallel_moves.len()];
-        for (i, &(src, _, _)) in self.parallel_moves.iter().enumerate() {
-            if let Ok(move_to_dst_idx) = self
-                .parallel_moves
-                .binary_search_by_key(&src, |&(_, dst, _)| dst)
-            {
-                must_come_before[i] = Some(move_to_dst_idx);
-            }
-        }
+        const NONE: usize = usize::MAX;
+        let must_come_before: SmallVec<[usize; 16]> = self
+            .parallel_moves
+            .iter()
+            .map(|&(src, _, _)| {
+                self.parallel_moves
+                    .binary_search_by_key(&src, |&(_, dst, _)| dst)
+                    .unwrap_or(NONE)
+            })
+            .collect();
 
         // Do a simple stack-based DFS and emit moves in postorder,
         // then reverse at the end for RPO. Unlike Tarjan's SCC
         // algorithm, we can emit a cycle as soon as we find one, as
         // noted above.
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum State {
+            /// Not on stack, not visited
+            ToDo,
+            /// On stack, not yet visited
+            Pending,
+            /// Visited
+            Done,
+        }
         let mut ret: MoveVec<T> = smallvec![];
         let mut stack: SmallVec<[usize; 16]> = smallvec![];
-        let mut visited: SmallVec<[bool; 16]> = smallvec![false; self.parallel_moves.len()];
-        let mut onstack: SmallVec<[bool; 16]> = smallvec![false; self.parallel_moves.len()];
+        let mut state: SmallVec<[State; 16]> = smallvec![State::ToDo; self.parallel_moves.len()];
         let mut scratch_used = false;
 
         stack.push(0);
-        onstack[0] = true;
+        state[0] = State::Pending;
         loop {
             if stack.is_empty() {
-                if let Some(next) = visited.iter().position(|&flag| !flag) {
+                if let Some(next) = state.iter().position(|&state| state == State::ToDo) {
                     stack.push(next);
-                    onstack[next] = true;
+                    state[next] = State::Pending;
                 } else {
                     break;
                 }
             }
 
             let top = *stack.last().unwrap();
-            visited[top] = true;
-            match must_come_before[top] {
-                None => {
+            debug_assert_eq!(state[top], State::Pending);
+            let next = must_come_before[top];
+            if next == NONE || state[next] == State::Done {
+                ret.push(self.parallel_moves[top]);
+                state[top] = State::Done;
+                stack.pop();
+                while let Some(top) = stack.pop() {
                     ret.push(self.parallel_moves[top]);
-                    onstack[top] = false;
-                    stack.pop();
-                    while let Some(top) = stack.pop() {
-                        ret.push(self.parallel_moves[top]);
-                        onstack[top] = false;
+                    state[top] = State::Done;
+                }
+            } else if state[next] == State::ToDo {
+                stack.push(next);
+                state[next] = State::Pending;
+            } else {
+                // Found a cycle -- emit a cyclic-move sequence
+                // for the cycle on the top of stack, then normal
+                // moves below it. Recall that these moves will be
+                // reversed in sequence, so from the original
+                // parallel move set
+                //
+                //     { B := A, C := B, A := B }
+                //
+                // we will generate something like:
+                //
+                //     A := scratch
+                //     B := A
+                //     C := B
+                //     scratch := C
+                //
+                // which will become:
+                //
+                //     scratch := C
+                //     C := B
+                //     B := A
+                //     A := scratch
+                let mut last_dst = None;
+                let mut scratch_src = None;
+                while let Some(move_idx) = stack.pop() {
+                    state[move_idx] = State::Done;
+                    let (mut src, dst, dst_t) = self.parallel_moves[move_idx];
+                    if last_dst.is_none() {
+                        scratch_src = Some(src);
+                        src = Allocation::none();
+                        scratch_used = true;
+                    } else {
+                        debug_assert_eq!(last_dst.unwrap(), src);
                     }
-                }
-                Some(next) if visited[next] && !onstack[next] => {
-                    ret.push(self.parallel_moves[top]);
-                    onstack[top] = false;
-                    stack.pop();
-                    while let Some(top) = stack.pop() {
-                        ret.push(self.parallel_moves[top]);
-                        onstack[top] = false;
-                    }
-                }
-                Some(next) if !visited[next] && !onstack[next] => {
-                    stack.push(next);
-                    onstack[next] = true;
-                    continue;
-                }
-                Some(next) => {
-                    // Found a cycle -- emit a cyclic-move sequence
-                    // for the cycle on the top of stack, then normal
-                    // moves below it. Recall that these moves will be
-                    // reversed in sequence, so from the original
-                    // parallel move set
-                    //
-                    //     { B := A, C := B, A := B }
-                    //
-                    // we will generate something like:
-                    //
-                    //     A := scratch
-                    //     B := A
-                    //     C := B
-                    //     scratch := C
-                    //
-                    // which will become:
-                    //
-                    //     scratch := C
-                    //     C := B
-                    //     B := A
-                    //     A := scratch
-                    let mut last_dst = None;
-                    let mut scratch_src = None;
-                    while let Some(move_idx) = stack.pop() {
-                        onstack[move_idx] = false;
-                        let (mut src, dst, dst_t) = self.parallel_moves[move_idx];
-                        if last_dst.is_none() {
-                            scratch_src = Some(src);
-                            src = Allocation::none();
-                            scratch_used = true;
-                        } else {
-                            debug_assert_eq!(last_dst.unwrap(), src);
-                        }
-                        ret.push((src, dst, dst_t));
+                    ret.push((src, dst, dst_t));
 
-                        last_dst = Some(dst);
+                    last_dst = Some(dst);
 
-                        if move_idx == next {
-                            break;
-                        }
+                    if move_idx == next {
+                        break;
                     }
-                    if let Some(src) = scratch_src {
-                        ret.push((src, Allocation::none(), T::default()));
-                    }
+                }
+                if let Some(src) = scratch_src {
+                    ret.push((src, Allocation::none(), T::default()));
                 }
             }
         }


### PR DESCRIPTION
I was trying to understand the public API of `ParallelMoves` by the method of reading the source, despite the presence of reasonable documentation I could have read instead, and I found some things about the implementation confusing. This PR makes it not confusing to me, which is hopefully a plus for others too?

One thing I'm not clear on: does anybody rely on the output move-list containing self-moves? If you tell the resolver that you want to move, say, `rdx` into `rdx`, the generated list of moves will have the same effects whether that self-move is included in the final list or not. But if the caller looks at the generated move list to pick a scratch register, for example, then removing the self-move could make the caller think that `rdx` is unused. Is that something to actually worry about?

Fuzzing this PR hasn't found any bugs in 50 million iterations, so I at least don't think it's an issue for the way the fuzz target uses this module.