### PR TITLE
Bump to version 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.9.2"
+version = "0.9.3"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
The current change set has been baking for a while, and it removes a lot of moves in the cranelift test suite.
