### PR TITLE
Allow fixed-early-def and fixed-late-use constraints

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -471,27 +471,25 @@ impl Func {
                         let i = u.int_in_range(0..=(operands.len() - 1))?;
                         let op = operands[i];
                         let fixed_reg = PReg::new(u.int_in_range(0..=62)?, op.class());
+                        if op.kind() == OperandKind::Def && op.pos() == OperandPos::Early {
+                            // Early-defs with fixed constraints conflict with
+                            // any other fixed uses of the same preg.
+                            if fixed_late.contains(&fixed_reg) {
+                                break;
+                            }
+                        }
+                        if op.kind() == OperandKind::Use && op.pos() == OperandPos::Late {
+                            // Late-use with fixed constraints conflict with
+                            // any other fixed uses of the same preg.
+                            if fixed_early.contains(&fixed_reg) {
+                                break;
+                            }
+                        }
                         let fixed_list = match op.pos() {
                             OperandPos::Early => &mut fixed_early,
                             OperandPos::Late => &mut fixed_late,
                         };
                         if fixed_list.contains(&fixed_reg) {
-                            break;
-                        }
-                        if op.kind() != OperandKind::Def && op.pos() == OperandPos::Late {
-                            // Late-uses/mods with fixed constraints
-                            // can't be allowed if we're allowing
-                            // different constraints at Early and
-                            // Late, because we can't move something
-                            // into a location between Early and
-                            // Late. Differing constraints only make
-                            // sense if the instruction itself
-                            // produces the newly-constrained values.
-                            break;
-                        }
-                        if op.kind() != OperandKind::Use && op.pos() == OperandPos::Early {
-                            // Likewise, we can *only* allow uses for
-                            // fixed constraints at Early.
                             break;
                         }
                         fixed_list.push(fixed_reg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -694,6 +694,28 @@ impl Operand {
         )
     }
 
+    /// Same as `reg_fixed_use` but at `OperandPos::Late`.
+    #[inline(always)]
+    pub fn reg_fixed_use_at_end(vreg: VReg, preg: PReg) -> Self {
+        Operand::new(
+            vreg,
+            OperandConstraint::FixedReg(preg),
+            OperandKind::Use,
+            OperandPos::Late,
+        )
+    }
+
+    /// Same as `reg_fixed_def` but at `OperandPos::Early`.
+    #[inline(always)]
+    pub fn reg_fixed_def_at_start(vreg: VReg, preg: PReg) -> Self {
+        Operand::new(
+            vreg,
+            OperandConstraint::FixedReg(preg),
+            OperandKind::Def,
+            OperandPos::Early,
+        )
+    }
+
     /// Create an `Operand` that designates a use of a vreg and places
     /// no constraints on its location (i.e., it can be allocated into
     /// either a register or on the stack).


### PR DESCRIPTION
These are useful to model fixed registers which should not be reused for other uses/defs. These were disallowed in #54, but this was too conservative.

Fundamentally, the only situation where a preg can be used in multiple fixed constraints within a single instruction is with an early-use and a late-def. Anything else is a user error because the live ranges will overlap.

As such this PR relaxes the operand rewrite from #54 to only apply in this specific situation. Fixed-late-use and fixed-early-def operands are left unchanged.