### PR TITLE
Remove support for backwards `InstRange`

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -172,7 +172,7 @@ impl FuncBuilder {
         let b = Block::new(self.f.blocks.len());
         self.f
             .blocks
-            .push(InstRange::forward(Inst::new(0), Inst::new(0)));
+            .push(InstRange::new(Inst::new(0), Inst::new(0)));
         self.f.block_preds.push(vec![]);
         self.f.block_succs.push(vec![]);
         self.f.block_params_in.push(vec![]);
@@ -217,7 +217,7 @@ impl FuncBuilder {
                 self.f.insts.push(inst.clone());
             }
             let end_inst = self.f.insts.len();
-            *blockrange = InstRange::forward(Inst::new(begin_inst), Inst::new(end_inst));
+            *blockrange = InstRange::new(Inst::new(begin_inst), Inst::new(end_inst));
         }
 
         self.f

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -315,7 +315,7 @@ impl<'a, F: Function> Env<'a, F> {
                 }
             }
 
-            for inst in insns.rev().iter() {
+            for inst in insns.iter().rev() {
                 for pos in &[OperandPos::Late, OperandPos::Early] {
                     for op in self.func.inst_operands(inst) {
                         if op.as_fixed_nonallocatable().is_some() {
@@ -442,7 +442,7 @@ impl<'a, F: Function> Env<'a, F> {
 
             // For each instruction, in reverse order, process
             // operands and clobbers.
-            for inst in insns.rev().iter() {
+            for inst in insns.iter().rev() {
                 // Mark clobbers with CodeRanges on PRegs.
                 for clobber in self.func.inst_clobbers(inst) {
                     // Clobber range is at After point only: an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub mod ssa;
 mod index;
 
 use alloc::vec::Vec;
-pub use index::{Block, Inst, InstRange, InstRangeIter};
+pub use index::{Block, Inst, InstRange};
 
 pub mod checker;
 


### PR DESCRIPTION
These are not needed except for one place in live range calculation where we can use a reversed iterator instead.