### PR TITLE
Disallow blockparams on branches with multiple successors

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -55,7 +55,7 @@ pub struct Func {
     block_preds: Vec<Vec<Block>>,
     block_succs: Vec<Vec<Block>>,
     block_params_in: Vec<Vec<VReg>>,
-    block_params_out: Vec<Vec<Vec<VReg>>>,
+    block_params_out: Vec<Vec<VReg>>,
     num_vregs: usize,
     reftype_vregs: Vec<VReg>,
     debug_value_labels: Vec<(VReg, Inst, Inst, u32)>,
@@ -99,8 +99,8 @@ impl Function for Func {
         self.insts[insn.index()].op == InstOpcode::Branch
     }
 
-    fn branch_blockparams(&self, block: Block, _: Inst, succ: usize) -> &[VReg] {
-        &self.block_params_out[block.index()][succ][..]
+    fn branch_blockparams(&self, block: Block, _: Inst) -> &[VReg] {
+        &self.block_params_out[block.index()][..]
     }
 
     fn requires_refs_on_stack(&self, insn: Inst) -> bool {
@@ -194,7 +194,7 @@ impl FuncBuilder {
         self.f.block_params_in[block.index()] = params.iter().cloned().collect();
     }
 
-    pub fn set_block_params_out(&mut self, block: Block, params: Vec<Vec<VReg>>) {
+    pub fn set_block_params_out(&mut self, block: Block, params: Vec<VReg>) {
         self.f.block_params_out[block.index()] = params;
     }
 
@@ -383,7 +383,11 @@ impl Func {
             let mut vregs_to_be_defined = vec![];
             let mut max_block_params = u.int_in_range(0..=core::cmp::min(3, vregs.len() / 3))?;
             for &vreg in &vregs {
-                if block > 0 && bool::arbitrary(u)? && max_block_params > 0 {
+                if block > 0
+                    && bool::arbitrary(u)?
+                    && max_block_params > 0
+                    && builder.f.block_preds[block].len() > 1
+                {
                     block_params[block].push(vreg);
                     max_block_params -= 1;
                 } else {
@@ -538,9 +542,9 @@ impl Func {
             // Define the branch with blockparam args that must end
             // the block.
             if builder.f.block_succs[block].len() > 0 {
-                let mut params = vec![];
-                for &succ in &builder.f.block_succs[block] {
-                    let mut args = vec![];
+                // Only add blockparams if there is a single successor.
+                if let [succ] = builder.f.block_succs[block][..] {
+                    let mut params = vec![];
                     for i in 0..builder.f.block_params_in[succ.index()].len() {
                         let dom_block = choose_dominating_block(
                             &builder.idom[..],
@@ -565,11 +569,10 @@ impl Func {
                             .copied()
                             .collect();
                         let vreg = u.choose(&suitable_vregs)?;
-                        args.push(*vreg);
+                        params.push(*vreg);
                     }
-                    params.push(args);
+                    builder.set_block_params_out(Block::new(block), params);
                 }
-                builder.set_block_params_out(Block::new(block), params);
                 builder.add_inst(Block::new(block), InstData::branch());
             } else {
                 builder.add_inst(Block::new(block), InstData::ret());
@@ -604,16 +607,7 @@ impl core::fmt::Debug for Func {
                 .join(", ");
             let params_out = self.block_params_out[i]
                 .iter()
-                .enumerate()
-                .map(|(succ_idx, vec)| {
-                    let succ = self.block_succs[i][succ_idx];
-                    let params = vec
-                        .iter()
-                        .map(|v| format!("v{}", v.vreg()))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    format!("block{}({})", succ.index(), params)
-                })
+                .map(|v| format!("v{}", v.vreg()))
                 .collect::<Vec<_>>()
                 .join(", ");
             write!(

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -307,11 +307,9 @@ impl<'a, F: Function> Env<'a, F> {
 
             // Include outgoing blockparams in the initial live set.
             if self.func.is_branch(insns.last()) {
-                for i in 0..self.func.block_succs(block).len() {
-                    for &param in self.func.branch_blockparams(block, insns.last(), i) {
-                        live.set(param.vreg(), true);
-                        self.observe_vreg_class(param);
-                    }
+                for &param in self.func.branch_blockparams(block, insns.last()) {
+                    live.set(param.vreg(), true);
+                    self.observe_vreg_class(param);
                 }
             }
 
@@ -399,24 +397,22 @@ impl<'a, F: Function> Env<'a, F> {
             // If the last instruction is a branch (rather than
             // return), create blockparam_out entries.
             if self.func.is_branch(insns.last()) {
-                for (i, &succ) in self.func.block_succs(block).iter().enumerate() {
-                    let blockparams_in = self.func.block_params(succ);
-                    let blockparams_out = self.func.branch_blockparams(block, insns.last(), i);
-                    for (&blockparam_in, &blockparam_out) in
-                        blockparams_in.iter().zip(blockparams_out)
-                    {
-                        let blockparam_out = VRegIndex::new(blockparam_out.vreg());
-                        let blockparam_in = VRegIndex::new(blockparam_in.vreg());
-                        self.blockparam_outs.push(BlockparamOut {
-                            to_vreg: blockparam_in,
-                            to_block: succ,
-                            from_block: block,
-                            from_vreg: blockparam_out,
-                        });
+                let succ = *self.func.block_succs(block).first().unwrap();
+                let blockparams_in = self.func.block_params(succ);
+                let blockparams_out = self.func.branch_blockparams(block, insns.last());
+                for (&blockparam_in, &blockparam_out) in blockparams_in.iter().zip(blockparams_out)
+                {
+                    let blockparam_out = VRegIndex::new(blockparam_out.vreg());
+                    let blockparam_in = VRegIndex::new(blockparam_in.vreg());
+                    self.blockparam_outs.push(BlockparamOut {
+                        to_vreg: blockparam_in,
+                        to_block: succ,
+                        from_block: block,
+                        from_vreg: blockparam_out,
+                    });
 
-                        // Include outgoing blockparams in the initial live set.
-                        live.set(blockparam_out.index(), true);
-                    }
+                    // Include outgoing blockparams in the initial live set.
+                    live.set(blockparam_out.index(), true);
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,11 @@ impl PRegSet {
         self.bits[0] |= other.bits[0];
         self.bits[1] |= other.bits[1];
     }
+
+    /// Checks whether the `PRegSet` is empty.
+    fn is_empty(self) -> bool {
+        self == Self::empty()
+    }
 }
 
 impl IntoIterator for PRegSet {
@@ -1043,10 +1048,10 @@ pub trait Function {
     fn is_branch(&self, insn: Inst) -> bool;
 
     /// If `insn` is a branch at the end of `block`, returns the
-    /// outgoing blockparam arguments for the given successor. The
-    /// number of arguments must match the number incoming blockparams
-    /// for each respective successor block.
-    fn branch_blockparams(&self, block: Block, insn: Inst, succ_idx: usize) -> &[VReg];
+    /// outgoing blockparam arguments. Branch arguments are only
+    /// allowed on blocks with a single successor. The number of
+    /// arguments must match the number incoming blockparams.
+    fn branch_blockparams(&self, block: Block, insn: Inst) -> &[VReg];
 
     /// Determine whether an instruction requires all reference-typed
     /// values to be placed onto the stack. For these instructions,


### PR DESCRIPTION
Since the input CFG is required to not have critical edges, such blockparams are useless. The incoming blockparams can simply be replaced with the vreg from the (unique) predecessor.

It's better to let the client's lowering code handle this so regalloc2 doesn't need to.