### PR TITLE
Keep all `Use`s in a single vector

### DIFF
--- a/src/ion/dump.rs
+++ b/src/ion/dump.rs
@@ -48,7 +48,7 @@ impl<'a, F: Function> Env<'a, F> {
                 r.bundle,
                 r.uses_spill_weight(),
             );
-            for u in &r.uses {
+            for u in &self.uses[r.uses()] {
                 trace!(" * use at {:?} (slot {}): {:?}", u.pos, u.slot, u.operand);
             }
         }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -239,7 +239,9 @@ impl<'a, F: Function> Env<'a, F> {
         // because those will be computed during the multi-fixed-reg
         // fixup pass later (after all uses are inserted).
 
-        self.ranges[into].uses.push(u);
+        // We also defer calculating the use range in the uses vector until
+        // that vector is sorted by vreg and position.
+        self.uses.push(u);
 
         // Update stats.
         let range_weight = self.ranges[into].uses_spill_weight() + weight;
@@ -770,15 +772,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
         }
 
-        for range in &mut self.ranges {
-            range.uses.reverse();
-            debug_assert!(range.uses.windows(2).all(|win| win[0].pos <= win[1].pos));
-        }
-
         // Insert safepoint virtual stack uses, if needed.
         for &vreg in self.func.reftype_vregs() {
             let vreg = VRegIndex::new(vreg.vreg());
-            let mut inserted = false;
             let mut safepoint_idx = 0;
             for range_idx in 0..self.vregs[vreg].ranges.len() {
                 let LiveRangeListEntry { range, index } = self.vregs[vreg].ranges[range_idx];
@@ -808,18 +804,33 @@ impl<'a, F: Function> Env<'a, F> {
 
                     self.insert_use_into_liverange(index, Use::new(operand, pos, SLOT_NONE));
                     safepoint_idx += 1;
-
-                    inserted = true;
-                }
-
-                if inserted {
-                    self.ranges[index].uses.sort_unstable_by_key(|u| u.pos);
                 }
 
                 if safepoint_idx >= self.safepoints.len() {
                     break;
                 }
             }
+        }
+
+        // Sort uses by VReg and by position (and by slot to keep the
+        // ordering stable). Then assign ranges of uses to each live range.
+        self.uses
+            .sort_unstable_by_key(|u| (u.operand.vreg(), u.pos, u.slot));
+        for range in &mut self.ranges {
+            let start = self.uses.partition_point(|u| {
+                VRegIndex::new(u.operand.vreg().vreg())
+                    .cmp(&range.vreg)
+                    .then(u.pos.cmp(&range.range.from))
+                    .is_lt()
+            });
+            let end = self.uses.partition_point(|u| {
+                VRegIndex::new(u.operand.vreg().vreg())
+                    .cmp(&range.vreg)
+                    .then(u.pos.cmp(&range.range.to))
+                    .is_lt()
+            });
+            debug_assert!(start <= end);
+            range.use_range = (start as u32)..(end as u32);
         }
 
         self.blockparam_ins.sort_unstable_by_key(|x| x.key());
@@ -849,7 +860,8 @@ impl<'a, F: Function> Env<'a, F> {
                 trace!("multi-fixed-reg cleanup: vreg {:?} range {:?}", vreg, range,);
 
                 // Find groups of uses that occur in at the same program point.
-                for uses in self.ranges[range].uses.linear_group_by_key_mut(|u| u.pos) {
+                for uses in self.uses[self.ranges[range].uses()].linear_group_by_key_mut(|u| u.pos)
+                {
                     if uses.len() < 2 {
                         continue;
                     }

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -265,7 +265,7 @@ impl<'a, F: Function> Env<'a, F> {
             let mut fixed_def = false;
             let mut stack = false;
             for entry in &self.bundles[bundle].ranges {
-                for u in &self.ranges[entry.index].uses {
+                for u in &self.uses[self.ranges[entry.index].uses()] {
                     if let OperandConstraint::FixedReg(_) = u.operand.constraint() {
                         fixed = true;
                         if u.operand.kind() == OperandKind::Def {

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -59,6 +59,7 @@ impl<'a, F: Function> Env<'a, F> {
             blockparam_ins: vec![],
             bundles: LiveBundles::with_capacity(n),
             ranges: LiveRanges::with_capacity(4 * n),
+            uses: Vec::with_capacity(8 * n),
             spillsets: SpillSets::with_capacity(n),
             vregs: VRegs::with_capacity(n),
             pregs: vec![],

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -556,8 +556,8 @@ impl<'a, F: Function> Env<'a, F> {
                 }
 
                 // Scan over def/uses and apply allocations.
-                for use_idx in 0..self.ranges[entry.index].uses.len() {
-                    let usedata = self.ranges[entry.index].uses[use_idx];
+                for use_idx in self.ranges[entry.index].uses() {
+                    let usedata = self.uses[use_idx];
                     trace!("applying to use: {:?}", usedata);
                     debug_assert!(range.contains_point(usedata.pos));
                     let inst = usedata.pos.inst();

--- a/src/ion/requirement.rs
+++ b/src/ion/requirement.rs
@@ -131,7 +131,7 @@ impl<'a, F: Function> Env<'a, F> {
         let ranges = &self.bundles[bundle].ranges;
         for entry in ranges {
             trace!(" -> LR {:?}: {:?}", entry.index, entry.range);
-            for u in &self.ranges[entry.index].uses {
+            for u in &self.uses[self.ranges[entry.index].uses()] {
                 trace!("  -> use {:?}", u);
                 let r = self.requirement_from_operand(u.operand);
                 req = req.merge(r).map_err(|_| {


### PR DESCRIPTION
Previously, each live range would carry a list of uses in a `SmallVec<[Use; 4]>`, which was an inefficient use of memory.

This PR instead keeps a single `Vec<Use>` for all uses in a function, sorted by vreg and position. Each live range now holds a `Range<u32>` of indices which refer to its uses inside this vector.

Benchmarks show that this consistently improves compilation times by ~2%.