### PR TITLE
Revert "Make parallel-moves resolver available publicly"

### DIFF
--- a/fuzz/fuzz_targets/moves.rs
+++ b/fuzz/fuzz_targets/moves.rs
@@ -6,7 +6,7 @@
 #![no_main]
 use regalloc2::fuzzing::arbitrary::{Arbitrary, Result, Unstructured};
 use regalloc2::fuzzing::fuzz_target;
-use regalloc2::moves::{MoveAndScratchResolver, ParallelMoves};
+use regalloc2::fuzzing::moves::{MoveAndScratchResolver, ParallelMoves};
 use regalloc2::{Allocation, PReg, RegClass, SpillSlot};
 use std::collections::{HashMap, HashSet};
 

--- a/src/fuzzing/mod.rs
+++ b/src/fuzzing/mod.rs
@@ -15,6 +15,9 @@ pub mod domtree {
 pub mod postorder {
     pub use crate::postorder::*;
 }
+pub mod moves {
+    pub use crate::moves::*;
+}
 pub mod cfg {
     pub use crate::cfg::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) mod cfg;
 pub(crate) mod domtree;
 pub mod indexset;
 pub(crate) mod ion;
-pub mod moves;
+pub(crate) mod moves;
 pub(crate) mod postorder;
 pub mod ssa;
 


### PR DESCRIPTION
Reverts bytecodealliance/regalloc2#156

We never used this functionality in Cranelift. When we tried, we discovered that's it's pretty tricky to use correctly outside of the specific context it was written for in RA2, and then we found out that we didn't need it at all. So let's revert making it public.