### PR TITLE
Upgrade cargo-deny to 0.14.22

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         submodules: true
     - run: |
         set -e
-        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.14.22/cargo-deny-0.14.22-x86_64-unknown-linux-musl.tar.gz | tar xzf -
         mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
         echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check


### PR DESCRIPTION
I think we need at least version 0.13.9, which includes https://github.com/EmbarkStudios/cargo-deny/pull/513 to fix checking for yanked crates with the new sparse crates.io index format. I'm upgrading to the newest release just in case there's anything else we might want.