### PR TITLE
PregSet machine env

### DIFF
--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -645,16 +645,24 @@ pub fn machine_env() -> MachineEnv {
     fn regs(r: core::ops::Range<usize>, c: RegClass) -> Vec<PReg> {
         r.map(|i| PReg::new(i, c)).collect()
     }
-    let preferred_regs_by_class: [PRegSet; 3] = [
-        regs(0..24, RegClass::Int).into(),
-        regs(0..24, RegClass::Float).into(),
-        regs(0..24, RegClass::Vector).into(),
-    ];
-    let non_preferred_regs_by_class: [PRegSet; 3] = [
-        regs(24..32, RegClass::Int).into(),
-        regs(24..32, RegClass::Float).into(),
-        regs(24..32, RegClass::Vector).into(),
-    ];
+    let int_regs: PRegSet = regs(0..24, RegClass::Int).into();
+    let float_regs: PRegSet = regs(0..24, RegClass::Float).into();
+    let vector_regs: PRegSet = regs(0..24, RegClass::Vector).into();
+
+    let mut preferred_regs_by_class = PRegSet::default();
+    preferred_regs_by_class.union_from(int_regs);
+    preferred_regs_by_class.union_from(float_regs);
+    preferred_regs_by_class.union_from(vector_regs);
+
+    let int_regs: PRegSet = regs(24..32, RegClass::Int).into();
+    let float_regs: PRegSet = regs(24..32, RegClass::Float).into();
+    let vector_regs: PRegSet = regs(24..32, RegClass::Vector).into();
+
+    let mut non_preferred_regs_by_class = PRegSet::default();
+    non_preferred_regs_by_class.union_from(int_regs);
+    non_preferred_regs_by_class.union_from(float_regs);
+    non_preferred_regs_by_class.union_from(vector_regs);
+
     let scratch_by_class: [Option<PReg>; 3] = [None, None, None];
     let fixed_stack_slots = (32..63)
         .flat_map(|i| {

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -645,15 +645,15 @@ pub fn machine_env() -> MachineEnv {
     fn regs(r: core::ops::Range<usize>, c: RegClass) -> Vec<PReg> {
         r.map(|i| PReg::new(i, c)).collect()
     }
-    let preferred_regs_by_class: [Vec<PReg>; 3] = [
-        regs(0..24, RegClass::Int),
-        regs(0..24, RegClass::Float),
-        regs(0..24, RegClass::Vector),
+    let preferred_regs_by_class: [PRegSet; 3] = [
+        regs(0..24, RegClass::Int).into(),
+        regs(0..24, RegClass::Float).into(),
+        regs(0..24, RegClass::Vector).into(),
     ];
-    let non_preferred_regs_by_class: [Vec<PReg>; 3] = [
-        regs(24..32, RegClass::Int),
-        regs(24..32, RegClass::Float),
-        regs(24..32, RegClass::Vector),
+    let non_preferred_regs_by_class: [PRegSet; 3] = [
+        regs(24..32, RegClass::Int).into(),
+        regs(24..32, RegClass::Float).into(),
+        regs(24..32, RegClass::Vector).into(),
     ];
     let scratch_by_class: [Option<PReg>; 3] = [None, None, None];
     let fixed_stack_slots = (32..63)

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -114,9 +114,8 @@ impl<'a, F: Function> Env<'a, F> {
         }
         for class in 0..self.preferred_victim_by_class.len() {
             self.preferred_victim_by_class[class] = self.env.non_preferred_regs_by_class[class]
-                .into_iter()
                 .last()
-                .or(self.env.preferred_regs_by_class[class].into_iter().last())
+                .or(self.env.preferred_regs_by_class[class].last())
                 // .cloned()
                 .unwrap_or(PReg::invalid());
         }

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -114,9 +114,10 @@ impl<'a, F: Function> Env<'a, F> {
         }
         for class in 0..self.preferred_victim_by_class.len() {
             self.preferred_victim_by_class[class] = self.env.non_preferred_regs_by_class[class]
+                .into_iter()
                 .last()
-                .or(self.env.preferred_regs_by_class[class].last())
-                .cloned()
+                .or(self.env.preferred_regs_by_class[class].into_iter().last())
+                // .cloned()
                 .unwrap_or(PReg::invalid());
         }
         // Create VRegs from the vreg count.

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -113,9 +113,11 @@ impl<'a, F: Function> Env<'a, F> {
             self.pregs[preg.index()].is_stack = true;
         }
         for class in 0..self.preferred_victim_by_class.len() {
-            self.preferred_victim_by_class[class] = self.env.non_preferred_regs_by_class[class]
-                .last()
-                .or(self.env.preferred_regs_by_class[class].last())
+            self.preferred_victim_by_class[class] = self
+                .env
+                .non_preferred_regs_by_class
+                .last_in_class(class)
+                .or(self.env.preferred_regs_by_class.last_in_class(class))
                 // .cloned()
                 .unwrap_or(PReg::invalid());
         }

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -1221,10 +1221,16 @@ impl<'a, F: Function> Env<'a, F> {
                     let mut min_bundles_assigned = 0;
                     let mut fixed_assigned = 0;
                     let mut total_regs = 0;
-                    for preg in self.env.preferred_regs_by_class[class as u8 as usize]
+                    for preg in self
+                        .env
+                        .preferred_regs_by_class
+                        .to_preg_class(class as u8 as usize)
                         .into_iter()
                         .chain(
-                            self.env.non_preferred_regs_by_class[class as u8 as usize].into_iter(),
+                            self.env
+                                .non_preferred_regs_by_class
+                                .to_preg_class(class as u8 as usize)
+                                .into_iter(),
                         )
                     {
                         trace!(" -> PR {:?}", preg);

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -1222,8 +1222,10 @@ impl<'a, F: Function> Env<'a, F> {
                     let mut fixed_assigned = 0;
                     let mut total_regs = 0;
                     for preg in self.env.preferred_regs_by_class[class as u8 as usize]
-                        .iter()
-                        .chain(self.env.non_preferred_regs_by_class[class as u8 as usize].iter())
+                        .into_iter()
+                        .chain(
+                            self.env.non_preferred_regs_by_class[class as u8 as usize].into_iter(),
+                        )
                     {
                         trace!(" -> PR {:?}", preg);
                         let start = LiveRangeKey::from_range(&CodeRange {

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -52,13 +52,13 @@ impl<'a> RegTraversalIter<'a> {
         }
         let hints = [hint_reg, hint2_reg];
         let class = class as u8 as usize;
-        let offset_pref = if env.preferred_regs_by_class[class].len() > 0 {
-            offset % env.preferred_regs_by_class[class].len()
+        let offset_pref = if env.preferred_regs_by_class.len_class(class) > 0 {
+            offset % env.preferred_regs_by_class.len_class(class)
         } else {
             0
         };
-        let offset_non_pref = if env.non_preferred_regs_by_class[class].len() > 0 {
-            offset % env.non_preferred_regs_by_class[class].len()
+        let offset_non_pref = if env.non_preferred_regs_by_class.len_class(class) > 0 {
+            offset % env.non_preferred_regs_by_class.len_class(class)
         } else {
             0
         };
@@ -100,9 +100,13 @@ impl<'a> core::iter::Iterator for RegTraversalIter<'a> {
             return h;
         }
 
-        let n_pref_regs = self.env.preferred_regs_by_class[self.class].len();
+        let n_pref_regs = self.env.preferred_regs_by_class.len_class(self.class);
         while self.pref_idx < n_pref_regs {
-            let mut arr = self.env.preferred_regs_by_class[self.class].into_iter();
+            let mut arr = self
+                .env
+                .preferred_regs_by_class
+                .to_preg_class(self.class)
+                .into_iter();
             let r = arr.nth(wrap(self.pref_idx + self.offset_pref, n_pref_regs));
             self.pref_idx += 1;
             if r == self.hints[0] || r == self.hints[1] {
@@ -111,9 +115,13 @@ impl<'a> core::iter::Iterator for RegTraversalIter<'a> {
             return r;
         }
 
-        let n_non_pref_regs = self.env.non_preferred_regs_by_class[self.class].len();
-        while self.non_pref_idx < self.env.non_preferred_regs_by_class[self.class].len() {
-            let mut arr = self.env.non_preferred_regs_by_class[self.class].into_iter();
+        let n_non_pref_regs = self.env.non_preferred_regs_by_class.len_class(self.class);
+        while self.non_pref_idx < n_non_pref_regs {
+            let mut arr = self
+                .env
+                .non_preferred_regs_by_class
+                .to_preg_class(self.class)
+                .into_iter();
             let r = arr.nth(wrap(
                 self.non_pref_idx + self.offset_non_pref,
                 n_non_pref_regs,

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -52,13 +52,13 @@ impl<'a> RegTraversalIter<'a> {
         }
         let hints = [hint_reg, hint2_reg];
         let class = class as u8 as usize;
-        let offset_pref = if env.preferred_regs_by_class[class].n_regs() > 0 {
-            offset % env.preferred_regs_by_class[class].n_regs()
+        let offset_pref = if env.preferred_regs_by_class[class].len() > 0 {
+            offset % env.preferred_regs_by_class[class].len()
         } else {
             0
         };
-        let offset_non_pref = if env.non_preferred_regs_by_class[class].n_regs() > 0 {
-            offset % env.non_preferred_regs_by_class[class].n_regs()
+        let offset_non_pref = if env.non_preferred_regs_by_class[class].len() > 0 {
+            offset % env.non_preferred_regs_by_class[class].len()
         } else {
             0
         };
@@ -100,7 +100,7 @@ impl<'a> core::iter::Iterator for RegTraversalIter<'a> {
             return h;
         }
 
-        let n_pref_regs = self.env.preferred_regs_by_class[self.class].n_regs();
+        let n_pref_regs = self.env.preferred_regs_by_class[self.class].len();
         while self.pref_idx < n_pref_regs {
             let mut arr = self.env.preferred_regs_by_class[self.class].into_iter();
             let r = arr.nth(wrap(self.pref_idx + self.offset_pref, n_pref_regs));
@@ -111,8 +111,8 @@ impl<'a> core::iter::Iterator for RegTraversalIter<'a> {
             return r;
         }
 
-        let n_non_pref_regs = self.env.non_preferred_regs_by_class[self.class].n_regs();
-        while self.non_pref_idx < self.env.non_preferred_regs_by_class[self.class].n_regs() {
+        let n_non_pref_regs = self.env.non_preferred_regs_by_class[self.class].len();
+        while self.non_pref_idx < self.env.non_preferred_regs_by_class[self.class].len() {
             let mut arr = self.env.non_preferred_regs_by_class[self.class].into_iter();
             let r = arr.nth(wrap(
                 self.non_pref_idx + self.offset_non_pref,

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -16,7 +16,6 @@ use crate::{MachineEnv, PReg, PRegClass, RegClass};
 pub struct RegTraversalIter {
     pref_regs_by_class: PRegClass,
     non_pref_regs_by_class: PRegClass,
-    class: usize,
     hints: [Option<PReg>; 2],
     hint_idx: usize,
     pref_idx: usize,
@@ -53,20 +52,23 @@ impl RegTraversalIter {
         }
         let hints = [hint_reg, hint2_reg];
         let class = class as u8 as usize;
-        let offset_pref = if env.preferred_regs_by_class.len_class(class) > 0 {
-            offset % env.preferred_regs_by_class.len_class(class)
+
+        let pref_regs_by_class = env.preferred_regs_by_class.to_preg_class(class);
+        let non_pref_regs_by_class = env.non_preferred_regs_by_class.to_preg_class(class);
+
+        let offset_pref = if pref_regs_by_class.len() > 0 {
+            offset % pref_regs_by_class.len()
         } else {
             0
         };
-        let offset_non_pref = if env.non_preferred_regs_by_class.len_class(class) > 0 {
-            offset % env.non_preferred_regs_by_class.len_class(class)
+        let offset_non_pref = if non_pref_regs_by_class.len() > 0 {
+            offset % non_pref_regs_by_class.len()
         } else {
             0
         };
         Self {
-            pref_regs_by_class: env.preferred_regs_by_class.to_preg_class(class),
-            non_pref_regs_by_class: env.non_preferred_regs_by_class.to_preg_class(class),
-            class,
+            pref_regs_by_class,
+            non_pref_regs_by_class,
             hints,
             hint_idx: 0,
             pref_idx: 0,

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -85,25 +85,22 @@ impl core::iter::Iterator for RegTraversalIter {
     type Item = PReg;
 
     fn next(&mut self) -> Option<PReg> {
+        // only take the fixed register if it exists
         if self.is_fixed {
             let ret = self.fixed;
             self.fixed = None;
             return ret;
         }
 
-        fn wrap(idx: usize, limit: usize) -> usize {
-            if idx >= limit {
-                idx - limit
-            } else {
-                idx
-            }
-        }
+        // if there are hints, return them first
         if self.hint_idx < 2 && self.hints[self.hint_idx].is_some() {
             let h = self.hints[self.hint_idx];
             self.hint_idx += 1;
             return h;
         }
 
+        // iterate over the preferred register rotated by offset
+        // ignoring hint register
         let n_pref_regs = self.pref_regs_by_class.len();
         while self.pref_idx < n_pref_regs {
             let mut arr = self.pref_regs_by_class.into_iter();
@@ -115,6 +112,8 @@ impl core::iter::Iterator for RegTraversalIter {
             return r;
         }
 
+        // iterate over the nonpreferred register rotated by offset
+        // ignoring hint register
         let n_non_pref_regs = self.non_pref_regs_by_class.len();
         while self.non_pref_idx < n_non_pref_regs {
             let mut arr = self.non_pref_regs_by_class.into_iter();
@@ -129,5 +128,14 @@ impl core::iter::Iterator for RegTraversalIter {
             return r;
         }
         None
+    }
+}
+
+/// Wrapping function to wrap around the index for an iterator
+fn wrap(idx: usize, limit: usize) -> usize {
+    if idx >= limit {
+        idx - limit
+    } else {
+        idx
     }
 }

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -153,12 +153,3 @@ impl core::iter::Iterator for RegTraversalIter {
         None
     }
 }
-
-/// Wrapping function to wrap around the index for an iterator
-fn wrap(idx: usize, limit: usize) -> usize {
-    if idx >= limit {
-        idx - limit
-    } else {
-        idx
-    }
-}

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -1,5 +1,5 @@
 use crate::{MachineEnv, PReg, RegClass};
-
+use alloc::vec::Vec;
 /// This iterator represents a traversal through all allocatable
 /// registers of a given class, in a certain order designed to
 /// minimize allocation contention.
@@ -53,13 +53,13 @@ impl<'a> RegTraversalIter<'a> {
         }
         let hints = [hint_reg, hint2_reg];
         let class = class as u8 as usize;
-        let offset_pref = if env.preferred_regs_by_class[class].len() > 0 {
-            offset % env.preferred_regs_by_class[class].len()
+        let offset_pref = if env.preferred_regs_by_class[class].n_regs() > 0 {
+            offset % env.preferred_regs_by_class[class].n_regs()
         } else {
             0
         };
-        let offset_non_pref = if env.non_preferred_regs_by_class[class].len() > 0 {
-            offset % env.non_preferred_regs_by_class[class].len()
+        let offset_non_pref = if env.non_preferred_regs_by_class[class].n_regs() > 0 {
+            offset % env.non_preferred_regs_by_class[class].n_regs()
         } else {
             0
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,7 @@ impl From<Vec<PReg>> for PRegSet {
 }
 
 /// A compact iterator over a single register class
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct PRegClass {
     // bit mask containing class data in UPPER two bits
     class_mask: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ pub(crate) fn find_nth(v: u64, mut r: u64) -> u8 {
     const E: u64 = 0b00110011_00110011_00110011_00110011_00110011_00110011_00110011_00110011; // 0x33333333
     const F: u64 = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101; // 0x55555555
 
-    // from https://graphics.stanford.edu/~seander/bithacks.html: uses 1 based indexing
+    // from https://graphics.stanford.edu/~seander/bithacks.html##SelectPosFromMSBRank: uses 1 based indexing
     let a = (v & F) + ((v >> 1) & F);
     let b = (a & E) + ((a >> 2) & E);
     let c = (b & D) + ((b >> 4) & D);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,64 @@ impl Iterator for PRegClass {
             Some(PReg::from(reg_index))
         }
     }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n >= self.len() {
+            self.regs = 0;
+            None
+        } else {
+            let n_from_right = self.len() - n;
+            // this is the number of trailing zeros for the n-th set bit from the right
+            let index = find_nth(self.regs, n_from_right as u64);
+            // clear those bits
+            self.regs &= u64::MAX << index;
+            self.regs &= !(1u64 << index);
+            // calculate the PReg
+            let reg_index = index as u8 | self.class_mask;
+            Some(PReg::from(reg_index))
+        }
+    }
+}
+
+// find the n-th set bit from the RIGHT,
+// using 1 based indexing
+// returns distance from the LEFT
+fn find_nth(v: u64, mut r: u64) -> u64 {
+    const C: u64 = 0b00000000_11111111_00000000_11111111_00000000_11111111_00000000_11111111; // 0x00FF00FF
+    const D: u64 = 0b00001111_00001111_00001111_00001111_00001111_00001111_00001111_00001111; // 0xF0F0F0F0
+    const E: u64 = 0b00110011_00110011_00110011_00110011_00110011_00110011_00110011_00110011; // 0x33333333
+    const F: u64 = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101; // 0x55555555
+
+    // from https://graphics.stanford.edu/~seander/bithacks.html: uses 1 based indexing
+    let a = (v & F) + ((v >> 1) & F);
+    let b = (a & E) + ((a >> 2) & E);
+    let c = (b & D) + ((b >> 4) & D);
+    let d = (c & C) + ((c >> 8) & C);
+    let mut t = (d >> 32) + (d >> 48);
+    let mut s = 64;
+    // if (r > t) {s -= 32; r -= t;}
+    s -= ((t - r) & 256) >> 3;
+    r -= t & ((t - r) >> 8);
+    t = (d >> (s - 16)) & 0xff;
+    // if (r > t) {s -= 16; r -= t;}
+    s -= ((t - r) & 256) >> 4;
+    r -= t & ((t - r) >> 8);
+    t = (c >> (s - 8)) & 0xf;
+    // if (r > t) {s -= 8; r -= t;}
+    s -= ((t - r) & 256) >> 5;
+    r -= t & ((t - r) >> 8);
+    t = (b >> (s - 4)) & 0x7;
+    // if (r > t) {s -= 4; r -= t;}
+    s -= ((t - r) & 256) >> 6;
+    r -= t & ((t - r) >> 8);
+    t = (a >> (s - 2)) & 0x3;
+    // if (r > t) {s -= 2; r -= t;}
+    s -= ((t - r) & 256) >> 7;
+    r -= t & ((t - r) >> 8);
+    t = (v >> (s - 1)) & 0x1;
+    // if (r > t) s--;
+    s -= ((t - r) & 256) >> 8;
+    s - 1
 }
 
 impl ExactSizeIterator for PRegClass {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,7 @@ impl PRegSet {
         self.bits[2] |= other.bits[2];
     }
 
+    /// Get the last register in a specific register class
     pub fn last_in_class(&self, class: usize) -> Option<PReg> {
         if self.bits[class] == 0 {
             None
@@ -261,6 +262,7 @@ impl PRegSet {
         }
     }
 
+    /// Get the number of registers in a specific register class
     pub fn len_class(&self, class: usize) -> usize {
         self.bits[class].count_ones() as usize
     }
@@ -278,17 +280,17 @@ impl Iterator for PRegSet {
     type Item = PReg;
     fn next(&mut self) -> Option<PReg> {
         if self.bits[0] != 0 {
-            let index = self.bits[0].trailing_zeros();
+            let index = self.bits[0].trailing_zeros() as u8;
             self.bits[0] &= !(1u64 << index);
-            Some(PReg::from_index(index as usize))
+            Some(PReg::from(index))
         } else if self.bits[1] != 0 {
-            let index = self.bits[1].trailing_zeros();
+            let index = self.bits[1].trailing_zeros() as u8;
             self.bits[1] &= !(1u64 << index);
-            Some(PReg::from_index(index as usize + 64))
+            Some(PReg::from(index + 64))
         } else if self.bits[2] != 0 {
-            let index = self.bits[2].trailing_zeros();
+            let index = self.bits[2].trailing_zeros() as u8;
             self.bits[2] &= !(1u64 << index);
-            Some(PReg::from_index(index as usize + 128))
+            Some(PReg::from(index + 128))
         } else {
             None
         }
@@ -303,14 +305,14 @@ impl Iterator for PRegSet {
 
     fn last(self) -> Option<PReg> {
         if self.bits[2] != 0 {
-            let index = 63 - self.bits[2].leading_zeros();
-            Some(PReg::from_index(index as usize + 128))
+            let index = 63 - self.bits[2].leading_zeros() as u8;
+            Some(PReg::from(index + 128))
         } else if self.bits[1] != 0 {
-            let index = 63 - self.bits[1].leading_zeros();
-            Some(PReg::from_index(index as usize + 64))
+            let index = 63 - self.bits[1].leading_zeros() as u8;
+            Some(PReg::from(index + 64))
         } else if self.bits[0] != 0 {
-            let index = 63 - self.bits[0].leading_zeros();
-            Some(PReg::from_index(index as usize))
+            let index = 63 - self.bits[0].leading_zeros() as u8;
+            Some(PReg::from(index))
         } else {
             None
         }
@@ -360,7 +362,7 @@ impl Iterator for PRegClass {
             let index = self.regs.trailing_zeros() as u8;
             self.regs &= !(1u64 << index);
             let reg_index = index as u8 | self.class_mask;
-            Some(PReg::from_index(reg_index as usize))
+            Some(PReg::from(reg_index))
         }
     }
 
@@ -375,7 +377,7 @@ impl Iterator for PRegClass {
         } else {
             let index = 63 - self.regs.leading_zeros();
             let reg_index = index as u8 | self.class_mask;
-            Some(PReg::from_index(reg_index as usize))
+            Some(PReg::from(reg_index))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,25 +241,13 @@ impl PRegSet {
         self.bits[1] |= other.bits[1];
     }
 
-    /// Get the number of registers in the set
-    pub fn n_regs(&self) -> usize {
-        self.bits[0].count_ones() as usize + self.bits[1].count_ones() as usize
-    }
+    // Get the number of registers in the set
+    // pub fn n_regs(&self) -> usize {
+    //     (self.bits[0].count_ones() + self.bits[1].count_ones()) as usize
+    // }
 }
 
-impl IntoIterator for PRegSet {
-    type Item = PReg;
-    type IntoIter = PRegSetIter;
-    fn into_iter(self) -> PRegSetIter {
-        PRegSetIter { bits: self.bits }
-    }
-}
-
-pub struct PRegSetIter {
-    bits: [u128; 2],
-}
-
-impl Iterator for PRegSetIter {
+impl Iterator for PRegSet {
     type Item = PReg;
     fn next(&mut self) -> Option<PReg> {
         if self.bits[0] != 0 {
@@ -273,6 +261,12 @@ impl Iterator for PRegSetIter {
         } else {
             None
         }
+    }
+}
+
+impl ExactSizeIterator for PRegSet {
+    fn len(&self) -> usize {
+        (self.bits[0].count_ones() + self.bits[1].count_ones()) as usize
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl PRegSet {
     pub fn add(&mut self, reg: PReg) {
         debug_assert!(reg.index() < 256);
         let bit = reg.index() & 63;
-        let index = reg.index() >> 3;
+        let index = reg.index() >> 6;
         self.bits[index] |= 1u64 << bit;
     }
 
@@ -236,7 +236,7 @@ impl PRegSet {
     pub fn remove(&mut self, reg: PReg) {
         debug_assert!(reg.index() < 256);
         let bit = reg.index() & 63;
-        let index = reg.index() >> 3;
+        let index = reg.index() >> 6;
         self.bits[index] &= !(1u64 << bit);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,18 @@ impl From<&MachineEnv> for PRegSet {
     }
 }
 
+impl From<Vec<PReg>> for PRegSet {
+    fn from(regs: Vec<PReg>) -> Self {
+        let mut res = Self::default();
+
+        for preg in regs {
+            res.add(preg);
+        }
+
+        res
+    }
+}
+
 /// A virtual register. Contains a virtual register number and a
 /// class.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,11 +400,11 @@ impl Iterator for PRegClass {
     }
 }
 
-// find the n-th set bit from the RIGHT,
+// find the r-th set bit in v from the RIGHT,
 // using 1 based indexing
 // returns distance from the LEFT
 // saturates on 0 if the bit requested exceeds the set amount
-fn find_nth(v: u64, mut r: u64) -> u8 {
+pub(crate) fn find_nth(v: u64, mut r: u64) -> u8 {
     const C: u64 = 0b00000000_11111111_00000000_11111111_00000000_11111111_00000000_11111111; // 0x00FF00FF
     const D: u64 = 0b00001111_00001111_00001111_00001111_00001111_00001111_00001111_00001111; // 0xF0F0F0F0
     const E: u64 = 0b00110011_00110011_00110011_00110011_00110011_00110011_00110011_00110011; // 0x33333333


### PR DESCRIPTION
As mentioned in https://github.com/bytecodealliance/wasmtime/pull/8489#issuecomment-2106379885 , use PRegSet instead of Vecs for storing the physical registers. I'm slightly unsure if I have done this correctly for the `reg_traversal` iterator however and am unsure how it's performance will change now its calling n iterator steps as opposed to indexing straight into an array