### PR TITLE
Added support for multiple OperandConstraint::Reuse operands.

### DIFF
--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -460,15 +460,14 @@ impl<'a, F: Function> Env<'a, F> {
                 // Does the instruction have any input-reusing
                 // outputs? This is important below to establish
                 // proper interference wrt other inputs. We note the
-                // *vreg* that is reused, not the index.
-                let mut reused_input = None;
+                // *vreg*s that are reused, not the index.
+                let mut reused_inputs: SmallVec<[VReg; 4]> = smallvec![];
                 for op in self.func.inst_operands(inst) {
                     if let OperandConstraint::Reuse(i) = op.constraint() {
                         debug_assert!(self.func.inst_operands(inst)[i]
                             .as_fixed_nonallocatable()
                             .is_none());
-                        reused_input = Some(self.func.inst_operands(inst)[i].vreg());
-                        break;
+                        reused_inputs.push(self.func.inst_operands(inst)[i].vreg())
                     }
                 }
 
@@ -592,8 +591,8 @@ impl<'a, F: Function> Env<'a, F> {
                             // the other inputs and the
                             // input-that-is-reused/output.
                             (OperandKind::Use, OperandPos::Early)
-                                if reused_input.is_some()
-                                    && reused_input.unwrap() != operand.vreg() =>
+                                if !reused_inputs.is_empty()
+                                    && !reused_inputs.contains(&operand.vreg()) =>
                             {
                                 ProgPoint::after(inst)
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,7 +788,7 @@ impl Operand {
     /// Rename the [`VReg`] associated with this operand by modifying
     /// the 32bit encoding directly.
     #[inline(always)]
-    pub fn rename_vreg_raw(&mut self, new_name: u32) {
+    pub fn set_vreg_raw(&mut self, new_name: u32) {
         self.bits = (self.bits & (!(VReg::MAX as u32))) | new_name
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,6 +778,20 @@ impl Operand {
         VReg::new(vreg_idx, self.class())
     }
 
+    /// Get the raw 32bit encoding of the [`VReg`] associated with this 
+    /// Operand
+    #[inline(always)]
+    pub fn vreg_raw(self) -> u32 {
+        self.bits & VReg::MAX as u32
+    }
+
+    /// Rename the [`VReg`] associated with this operand by modifying
+    /// the 32bit encoding directly.
+    #[inline(always)]
+    pub fn rename_vreg_raw(&mut self, new_name: u32) {
+        self.bits = (self.bits & (!(VReg::MAX as u32))) | new_name
+    }
+
     /// Get the register class used by this operand.
     #[inline(always)]
     pub fn class(self) -> RegClass {


### PR DESCRIPTION
Previously instructions that have multiple operands specifying the constraint `OperandConstraint::Reuse` would not work properly. Good examples of this are X86's `XCHG` and `XADD`, both of which require two `OperandConstraint::Reuse`s. This PR addresses this issue and fixes it by using a `SmallVec<[VReg; 4]>` to store all reuse constraints to check, instead of a single `Option<VReg>`.

I ran 8 instances of ion_checker overnight without fail. Additionally, the fixes have enabled my compiler to correctly emit the aforementioned instructions and it passes my own test suite. I'm not however confident that the ion_checker correctly generates these types of instructions as prior to this change it was still reporting no errors. It also seems to only generate one Def per instruction.

I will be leaving a comment in #145 as I discovered some interesting things about that as well while looking into this.