### PR TITLE
Added support for multiple OperandConstraint::Reuse operands.

### DIFF
--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -460,15 +460,14 @@ impl<'a, F: Function> Env<'a, F> {
                 // Does the instruction have any input-reusing
                 // outputs? This is important below to establish
                 // proper interference wrt other inputs. We note the
-                // *vreg* that is reused, not the index.
-                let mut reused_input = None;
+                // *vreg*s that are reused, not the index.
+                let mut reused_inputs: SmallVec<[VReg; 4]> = smallvec![];
                 for op in self.func.inst_operands(inst) {
                     if let OperandConstraint::Reuse(i) = op.constraint() {
                         debug_assert!(self.func.inst_operands(inst)[i]
                             .as_fixed_nonallocatable()
                             .is_none());
-                        reused_input = Some(self.func.inst_operands(inst)[i].vreg());
-                        break;
+                        reused_inputs.push(self.func.inst_operands(inst)[i].vreg())
                     }
                 }
 
@@ -592,8 +591,8 @@ impl<'a, F: Function> Env<'a, F> {
                             // the other inputs and the
                             // input-that-is-reused/output.
                             (OperandKind::Use, OperandPos::Early)
-                                if reused_input.is_some()
-                                    && reused_input.unwrap() != operand.vreg() =>
+                                if !reused_inputs.is_empty()
+                                    && !reused_inputs.contains(&operand.vreg()) =>
                             {
                                 ProgPoint::after(inst)
                             }


### PR DESCRIPTION
Previously instructions that have multiple operands specifying the constraint `OperandConstraint::Reuse` would not work properly. Good examples of this are X86's `XCHG` and `XADD`, both of which require two `OperandConstraint::Reuses`. This PR addresses this issue and fixes it by using a `SmallVec<[VReg; 4]>` to store all reuse constraints to check, instead of a single `Option<VReg>`.

I ran 8 instances of ion_checker overnight without fail. Additionally, the fixes have enabled my compiler to correctly emit the aforementioned instructions and it passes my own test suite. I'm not however confident that the ion_checker correctly generates these types of instructions as prior to this change it was still reporting no errors. It also seems to only generate one Def per instruction.

I will be leaving a comment in https://github.com/bytecodealliance/regalloc2/issues/145 as I discovered some interesting things about that as well while looking into this.

As discussed in the other PR(sorry I had to recreate to change source branch) I will look into changing the fuzzer, I will hopefully find time to do this within the coming week or two.