### PR TITLE
Release version 0.9.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.9.3"
+version = "0.9.4"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
There have been a lot of changes since the 0.9.3 release, and it looks like they improve the quality of generated code in cranelift. Let's release 0.9.4!
