### PR TITLE
Remove the OperandConstraint::Stack variant

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -648,14 +648,11 @@ other):
 
 ```plain
 
-        ___Unknown_____
-        |      |      |
-        |      |      |
-        | ____Any(rc) |
-        |/     |      |
-   Stack(rc)  FixedReg(reg)
-         \    /
-        Conflict
+                         Any(rc)
+                        /       \
+              FixedReg(reg)   FixedStack(reg)
+                        \       /
+                         Conflict
 ```
 
 Once we have the Requirement for a bundle, we can decide what to do.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -649,17 +649,6 @@ impl CheckerState {
                 }
                 return Err(CheckerError::AllocationIsNotReg { inst, op, alloc });
             }
-            OperandConstraint::Stack => {
-                if alloc.kind() != AllocationKind::Stack {
-                    // Accept pregs that represent a fixed stack slot.
-                    if let Some(preg) = alloc.as_reg() {
-                        if checker.machine_env.fixed_stack_slots.contains(&preg) {
-                            return Ok(());
-                        }
-                    }
-                    return Err(CheckerError::AllocationIsNotStack { inst, op, alloc });
-                }
-            }
             OperandConstraint::FixedReg(preg) => {
                 if alloc != Allocation::reg(preg) {
                     return Err(CheckerError::AllocationIsNotFixedReg { inst, op, alloc });

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -216,14 +216,12 @@ impl LiveBundle {
         minimal: bool,
         fixed: bool,
         fixed_def: bool,
-        stack: bool,
     ) {
         debug_assert!(spill_weight <= BUNDLE_MAX_SPILL_WEIGHT);
         self.spill_weight_and_props = spill_weight
             | (if minimal { 1 << 31 } else { 0 })
             | (if fixed { 1 << 30 } else { 0 })
-            | (if fixed_def { 1 << 29 } else { 0 })
-            | (if stack { 1 << 28 } else { 0 });
+            | (if fixed_def { 1 << 29 } else { 0 });
     }
 
     #[inline(always)]

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -203,7 +203,7 @@ pub struct LiveBundle {
     pub spill_weight_and_props: u32,
 }
 
-pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 28) - 1;
+pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 29) - 1;
 pub const MINIMAL_FIXED_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT;
 pub const MINIMAL_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 1;
 pub const BUNDLE_MAX_NORMAL_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 2;

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -805,10 +805,6 @@ impl<'a, F: Function> Env<'a, F> {
                                     first_reg_slot.get_or_insert(u.slot);
                                 }
                             }
-                            // Maybe this could be supported in this future...
-                            OperandConstraint::Stack => panic!(
-                                "multiple uses of vreg with a Stack constraint are not supported"
-                            ),
                         }
                     }
 

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -263,7 +263,6 @@ impl<'a, F: Function> Env<'a, F> {
 
             let mut fixed = false;
             let mut fixed_def = false;
-            let mut stack = false;
             for entry in &self.bundles[bundle].ranges {
                 for u in &self.ranges[entry.index].uses {
                     if let OperandConstraint::FixedReg(_) = u.operand.constraint() {
@@ -272,10 +271,7 @@ impl<'a, F: Function> Env<'a, F> {
                             fixed_def = true;
                         }
                     }
-                    if let OperandConstraint::Stack = u.operand.constraint() {
-                        stack = true;
-                    }
-                    if fixed && stack && fixed_def {
+                    if fixed && fixed_def {
                         break;
                     }
                 }
@@ -285,9 +281,6 @@ impl<'a, F: Function> Env<'a, F> {
             }
             if fixed_def {
                 self.bundles[bundle].set_cached_fixed_def();
-            }
-            if stack {
-                self.bundles[bundle].set_cached_stack();
             }
 
             // Create a spillslot for this bundle.

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -265,7 +265,6 @@ impl<'a, F: Function> Env<'a, F> {
         let minimal;
         let mut fixed = false;
         let mut fixed_def = false;
-        let mut stack = false;
         let bundledata = &self.bundles[bundle];
         let first_range = bundledata.ranges[0].index;
         let first_range_data = &self.ranges[first_range];
@@ -286,12 +285,7 @@ impl<'a, F: Function> Env<'a, F> {
                         trace!("  -> is fixed def");
                         fixed_def = true;
                     }
-                }
-                if let OperandConstraint::Stack = u.operand.constraint() {
-                    trace!("  -> stack operand at {:?}: {:?}", u.pos, u.operand);
-                    stack = true;
-                }
-                if stack && fixed {
+
                     break;
                 }
             }
@@ -343,7 +337,6 @@ impl<'a, F: Function> Env<'a, F> {
             minimal,
             fixed,
             fixed_def,
-            stack,
         );
     }
 
@@ -1056,12 +1049,6 @@ impl<'a, F: Function> Env<'a, F> {
             let fixed_preg = match req {
                 Requirement::FixedReg(preg) | Requirement::FixedStack(preg) => Some(preg),
                 Requirement::Register => None,
-                Requirement::Stack => {
-                    // If we must be on the stack, mark our spillset
-                    // as required immediately.
-                    self.spillsets[self.bundles[bundle].spillset].required = true;
-                    return Ok(());
-                }
 
                 Requirement::Any => {
                     self.spilled_bundles.push(bundle);

--- a/src/ion/requirement.rs
+++ b/src/ion/requirement.rs
@@ -61,7 +61,6 @@ pub enum Requirement {
     FixedReg(PReg),
     FixedStack(PReg),
     Register,
-    Stack,
     Any,
 }
 impl Requirement {
@@ -70,14 +69,9 @@ impl Requirement {
         match (self, other) {
             (other, Requirement::Any) | (Requirement::Any, other) => Ok(other),
             (Requirement::Register, Requirement::Register) => Ok(self),
-            (Requirement::Stack, Requirement::Stack) => Ok(self),
             (Requirement::Register, Requirement::FixedReg(preg))
             | (Requirement::FixedReg(preg), Requirement::Register) => {
                 Ok(Requirement::FixedReg(preg))
-            }
-            (Requirement::Stack, Requirement::FixedStack(preg))
-            | (Requirement::FixedStack(preg), Requirement::Stack) => {
-                Ok(Requirement::FixedStack(preg))
             }
             (Requirement::FixedReg(a), Requirement::FixedReg(b)) if a == b => Ok(self),
             (Requirement::FixedStack(a), Requirement::FixedStack(b)) if a == b => Ok(self),
@@ -88,7 +82,7 @@ impl Requirement {
     #[inline(always)]
     pub fn is_stack(self) -> bool {
         match self {
-            Requirement::Stack | Requirement::FixedStack(..) => true,
+            Requirement::FixedStack(..) => true,
             Requirement::Register | Requirement::FixedReg(..) => false,
             Requirement::Any => false,
         }
@@ -98,7 +92,7 @@ impl Requirement {
     pub fn is_reg(self) -> bool {
         match self {
             Requirement::Register | Requirement::FixedReg(..) => true,
-            Requirement::Stack | Requirement::FixedStack(..) => false,
+            Requirement::FixedStack(..) => false,
             Requirement::Any => false,
         }
     }
@@ -116,7 +110,6 @@ impl<'a, F: Function> Env<'a, F> {
                 }
             }
             OperandConstraint::Reg | OperandConstraint::Reuse(_) => Requirement::Register,
-            OperandConstraint::Stack => Requirement::Stack,
             OperandConstraint::Any => Requirement::Any,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,8 +447,6 @@ pub enum OperandConstraint {
     Any,
     /// Operand must be in a register. Register is read-only for Uses.
     Reg,
-    /// Operand must be on the stack.
-    Stack,
     /// Operand must be in a fixed register.
     FixedReg(PReg),
     /// On defs only: reuse a use's register.
@@ -460,7 +458,6 @@ impl core::fmt::Display for OperandConstraint {
         match self {
             Self::Any => write!(f, "any"),
             Self::Reg => write!(f, "reg"),
-            Self::Stack => write!(f, "stack"),
             Self::FixedReg(preg) => write!(f, "fixed({})", preg),
             Self::Reuse(idx) => write!(f, "reuse({})", idx),
         }
@@ -556,7 +553,6 @@ impl Operand {
         let constraint_field = match constraint {
             OperandConstraint::Any => 0,
             OperandConstraint::Reg => 1,
-            OperandConstraint::Stack => 2,
             OperandConstraint::FixedReg(preg) => {
                 debug_assert_eq!(preg.class(), vreg.class());
                 0b1000000 | preg.hw_enc() as u32
@@ -829,7 +825,6 @@ impl Operand {
             match constraint_field {
                 0 => OperandConstraint::Any,
                 1 => OperandConstraint::Reg,
-                2 => OperandConstraint::Stack,
                 _ => unreachable!(),
             }
         }


### PR DESCRIPTION
Following on from the removal of safepoints, remove the `OperandConstraint::Stack` and `Requirement::Stack` enum variants, as there's no longer any way to construct them.

Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>
