### PR TITLE
Bump to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.9.4"
+version = "0.10.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
Release version 0.10.0, which includes removing support for `InstRange::backwards` and support for generating safe points.