### PR TITLE
Version 0.10.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
As per #188, a new point-release that includes a version-bump of `rustc-hash` (and no other changes).