### PR TITLE
Stop moving Early FixedReg Use operands in certain conditions when Reuse operands are present.

### DIFF
--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -594,7 +594,17 @@ impl<'a, F: Function> Env<'a, F> {
                                 if !reused_inputs.is_empty()
                                     && !reused_inputs.contains(&operand.vreg()) =>
                             {
-                                ProgPoint::after(inst)
+                                if let OperandConstraint::FixedReg(preg) = operand.constraint() {
+                                    if self.func.inst_clobbers(inst).contains(preg)
+                                        || late_def_fixed.contains(&preg)
+                                    {
+                                        ProgPoint::before(inst)
+                                    } else {
+                                        ProgPoint::after(inst)
+                                    }
+                                } else {
+                                    ProgPoint::after(inst)
+                                }
                             }
                             (OperandKind::Use, OperandPos::Early) => ProgPoint::before(inst),
                         };

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -460,15 +460,14 @@ impl<'a, F: Function> Env<'a, F> {
                 // Does the instruction have any input-reusing
                 // outputs? This is important below to establish
                 // proper interference wrt other inputs. We note the
-                // *vreg* that is reused, not the index.
-                let mut reused_input = None;
+                // *vreg*s that are reused, not the index.
+                let mut reused_inputs: SmallVec<[VReg; 4]> = smallvec![];
                 for op in self.func.inst_operands(inst) {
                     if let OperandConstraint::Reuse(i) = op.constraint() {
                         debug_assert!(self.func.inst_operands(inst)[i]
                             .as_fixed_nonallocatable()
                             .is_none());
-                        reused_input = Some(self.func.inst_operands(inst)[i].vreg());
-                        break;
+                        reused_inputs.push(self.func.inst_operands(inst)[i].vreg())
                     }
                 }
 
@@ -592,8 +591,8 @@ impl<'a, F: Function> Env<'a, F> {
                             // the other inputs and the
                             // input-that-is-reused/output.
                             (OperandKind::Use, OperandPos::Early)
-                                if reused_input.is_some()
-                                    && reused_input.unwrap() != operand.vreg() =>
+                                if !reused_inputs.is_empty()
+                                    && !reused_inputs.contains(&operand.vreg()) =>
                             {
                                 ProgPoint::after(inst)
                             }


### PR DESCRIPTION
One of the reasons for the panic at [here](https://github.com/bytecodealliance/regalloc2/blob/main/src/ion/process.rs#L1253) is that `Early FixedReg Uses` are having their position updated to `Late` when there is already a `Late FixedReg Def` or clobber of the fixed `PReg`. This fixes that by not moving the operand's position if one of these already exist.

It's still possible to cause this behavior if a `Late Def` operand `Reuse`s an `Early FixedReg Def`. However that is also easy to fix if `Reuse` operands are checked to see if they reuse a `FixedReg` operand.

Thoughts? Am I missing something here? I ran the fuzzer overnight and compiled a few large binaries 200mb plus without fail; All run fine.
