### PR TITLE
Fix bit packing of bundle params

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -240,11 +240,6 @@ impl LiveBundle {
     }
 
     #[inline(always)]
-    pub fn cached_stack(&self) -> bool {
-        self.spill_weight_and_props & (1 << 28) != 0
-    }
-
-    #[inline(always)]
     pub fn set_cached_fixed(&mut self) {
         self.spill_weight_and_props |= 1 << 30;
     }
@@ -255,13 +250,7 @@ impl LiveBundle {
     }
 
     #[inline(always)]
-    pub fn set_cached_stack(&mut self) {
-        self.spill_weight_and_props |= 1 << 28;
-    }
-
-    #[inline(always)]
     pub fn cached_spill_weight(&self) -> u32 {
-        self.spill_weight_and_props & ((1 << 28) - 1)
         self.spill_weight_and_props & BUNDLE_MAX_SPILL_WEIGHT
     }
 }

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -262,6 +262,7 @@ impl LiveBundle {
     #[inline(always)]
     pub fn cached_spill_weight(&self) -> u32 {
         self.spill_weight_and_props & ((1 << 28) - 1)
+        self.spill_weight_and_props & BUNDLE_MAX_SPILL_WEIGHT
     }
 }
 

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -110,11 +110,7 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         // Check for a requirements conflict.
-        if self.bundles[from].cached_stack()
-            || self.bundles[from].cached_fixed()
-            || self.bundles[to].cached_stack()
-            || self.bundles[to].cached_fixed()
-        {
+        if self.bundles[from].cached_fixed() || self.bundles[to].cached_fixed() {
             if self.merge_bundle_requirements(from, to).is_err() {
                 trace!(" -> conflicting requirements; aborting merge");
                 return false;
@@ -155,9 +151,6 @@ impl<'a, F: Function> Env<'a, F> {
             }
             self.bundles[to].ranges = list;
 
-            if self.bundles[from].cached_stack() {
-                self.bundles[to].set_cached_stack();
-            }
             if self.bundles[from].cached_fixed() {
                 self.bundles[to].set_cached_fixed();
             }
@@ -224,9 +217,6 @@ impl<'a, F: Function> Env<'a, F> {
             *to_range = to_range.join(from_range);
         }
 
-        if self.bundles[from].cached_stack() {
-            self.bundles[to].set_cached_stack();
-        }
         if self.bundles[from].cached_fixed() {
             self.bundles[to].set_cached_fixed();
         }


### PR DESCRIPTION
Fix a fuzzbug introduced in #185 where we missed updating a mask after also updating a constant indicating that the bit was no longer used. This PR fixes the bug by using the appropriate constant when masking, and also removing some additional functions that were missed in #185.

co-authored-by: Chris Fallin <chris@cfallin.org>
