### PR TITLE
Remove some final references to stack maps

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -162,15 +162,6 @@ pub enum CheckerError {
         op: Operand,
         alloc: Allocation,
     },
-    ConflictedValueInStackmap {
-        inst: Inst,
-        alloc: Allocation,
-    },
-    NonRefValuesInStackmap {
-        inst: Inst,
-        alloc: Allocation,
-        vregs: FxHashSet<VReg>,
-    },
     StackToStackMove {
         into: Allocation,
         from: Allocation,


### PR DESCRIPTION
Stack maps are not provided by regalloc2 anymore. This removes the final references to stack maps in the codebase.