### PR TITLE
Bump to version 0.11.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.10.2"
+version = "0.11.0"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
This includes two major updates:

- The new single-pass fast allocator (#181);
- An ability to reuse allocations across runs (#196).