### PR TITLE
Improve performance by optimizing  bundle merging logic.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-apple-darwin" },
@@ -7,8 +8,6 @@ targets = [
 
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
 yanked = "deny"
 ignore = []
 
@@ -19,6 +18,7 @@ allow = [
     "Apache-2.0",
     "MIT",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html


### PR DESCRIPTION
While merging two bundles, the `merge_bundles` function appends two sorted vectors and sort the resulting vector again. This approach used to be fast in most cases, but rustc 1.81 introduced changes in sorting algorithm that made `sort_unstable_by_key` to behave very bad with vectors that are almost sorted.

This introduces an optimization consisting in handling the special case where the vector being appended contains a single item differently. This case is very common, and there's a benefit in handling it differently both with rust 1.81 and with earlier versions.

Fixes #203 