### PR TITLE
Panics on non consecutive blocks and vregs ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 Cargo.lock
-target/
+target
 .*.swp
 *~

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -56,7 +56,7 @@ impl CFGInfo {
             &mut ctx.visited,
             &mut self.postorder,
             |block| f.block_succs(block),
-        );
+        )?;
 
         domtree::calculate(
             nb,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -65,12 +65,12 @@
 //!
 //!   - `Edit::Move` inserted by RA:       [ alloc_d := alloc_s ]
 //!
-//!       A' = A[alloc_d → A[alloc_s]]
+//!       A' = A[alloc_d → A\[alloc_s\]]
 //!
 //!   - statement in pre-regalloc function [ V_i := op V_j, V_k, ... ]
 //!     with allocated form                [ A_i := op A_j, A_k, ... ]
 //!
-//!       A' = { A_k → A[A_k] \ { V_i } for k ≠ i } ∪
+//!       A' = { A_k → A\[A_k\] \ { V_i } for k ≠ i } ∪
 //!            { A_i -> { V_i } }
 //!
 //!     In other words, a statement, even after allocation, generates
@@ -81,7 +81,7 @@
 //!   - Parallel moves or blockparam-assignments in original program
 //!                                       [ V_d1 := V_s1, V_d2 := V_s2, ... ]
 //!
-//!       A' = { A_k → subst(A[A_k]) for all k }
+//!       A' = { A_k → subst(A\[A_k\]) for all k }
 //!            where subst(S) removes symbols for overwritten virtual
 //!            registers (V_d1 .. V_dn) and then adds V_di whenever
 //!            V_si appeared prior to the removals.

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -189,7 +189,7 @@ impl FuncBuilder {
 
     fn compute_doms(&mut self) {
         let f = &self.f;
-        postorder::calculate(
+        let _ = postorder::calculate(
             self.f.blocks.len(),
             Block::new(0),
             &mut vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,7 +912,7 @@ impl Operand {
     }
 
     /// If this operand is for a fixed non-allocatable register (see
-    /// [`OperandConstraint::FixedReg`]), then returns the physical register that it will
+    /// [`Operand::fixed_nonallocatable`]), then returns the physical register that it will
     /// be assigned to.
     #[inline(always)]
     pub fn as_fixed_nonallocatable(self) -> Option<PReg> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,7 +912,7 @@ impl Operand {
     }
 
     /// If this operand is for a fixed non-allocatable register (see
-    /// [`Operand::fixed`]), then returns the physical register that it will
+    /// [`OperandConstraint::FixedReg`]), then returns the physical register that it will
     /// be assigned to.
     #[inline(always)]
     pub fn as_fixed_nonallocatable(self) -> Option<PReg> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1120,6 +1120,9 @@ pub enum AllocationKind {
 ///
 /// (This trait's design is inspired by, and derives heavily from, the
 /// trait of the same name in regalloc.rs.)
+///
+/// The ids used in [`Block`] and [`VReg`] must start their numbering
+/// at zero and be sequential.
 pub trait Function {
     // -------------
     // CFG traversal
@@ -1557,10 +1560,12 @@ pub enum RegAllocError {
     /// a block param.
     SSA(VReg, Inst),
     /// Invalid basic block: does not end in branch/ret, or contains a
-    /// branch/ret in the middle.
+    /// branch/ret in the middle, or the VReg ids do not start at zero
+    /// or aren't numbered sequentially.
     BB(Block),
     /// Invalid branch: operand count does not match sum of block
-    /// params of successor blocks.
+    /// params of successor blocks, or the block ids do not start at
+    /// zero or aren't numbered sequentially.
     Branch(Inst),
     /// A VReg is live-in on entry; this is not allowed.
     EntryLivein,

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -16,6 +16,10 @@ pub fn validate_ssa<F: Function>(f: &F, cfginfo: &CFGInfo) -> Result<(), RegAllo
     for block in 0..f.num_blocks() {
         let block = Block::new(block);
         let mut def = |vreg: VReg, inst| {
+            if vreg.vreg() >= defined_in.len() {
+                trace!("VRegs not numbered consecutively {:?}", vreg);
+                return Err(RegAllocError::SSA(vreg, inst));
+            }
             if defined_in[vreg.vreg()].is_valid() {
                 trace!("Multiple def constraints for {:?}", vreg);
                 Err(RegAllocError::SSA(vreg, inst))


### PR DESCRIPTION
Hi, currently it is possible for two panics to happen when a function's SSA is being validated:
- If the block's numbering does not start at `0` or is non consecutive.
- If the vreg's numbering does not start at `0` or is non consecutive.

I ran into it after trying to use regalloc2's allocators in my toy/educational compiler project... I ended up with a hacked up clif file, something like:
```
test run
test compile
target x86_64

function %branch_diverge(i64, i64) -> i64 system_v {

block1(v0: i64, v1: i64):
    brif v0, block2, block2

block2:
    v6 = iconst.i64 1
    v11 = iadd v6, v1
    return v11
}
; run: %branch_diverge(0, 0) == 1
```
Which worked fine in my register allocator, as it uses hashmaps, but when trying to run regalloc2's allocators I got panics. Running `clif-util test` from cranelift passes on this file, that probably relabels all ids before passing them to the register allocator?.

I'm not sure if non conseuctive ids violate an unwritten rule about SSA notation, but I didn't find anything in the documentation about this and if it is not allowed, ideally the ssa validation should catch it and report an error, such that users can easily understand what the problem is.


The first one happens in the [second argument](https://github.com/bytecodealliance/regalloc2/blob/925df1b4674435a9322e21912926a68749517861/src/fastalloc/mod.rs#L1290) of the `validate_ssa` call. Specifically here:
https://github.com/bytecodealliance/regalloc2/blob/925df1b4674435a9322e21912926a68749517861/src/postorder.rs#L38
in the case the index of a block is outside of `num_blocks`.

The other one here:
https://github.com/bytecodealliance/regalloc2/blob/925df1b4674435a9322e21912926a68749517861/src/ssa.rs#L19
In case the vregs ids are not consecutive.

A standalone minimal example that demonstrates the two problems can be found [here](https://gist.github.com/iwanders/433881a4d601e6e7d89fb817d146a0c6).

<details>
<summary>Backtraces from that example</summary>

```
thread 'main' panicked at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/postorder.rs:38:17:
index out of bounds: the len is 2 but the index is 2
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_bounds_check
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:273:5
   3: regalloc2::postorder::calculate
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/postorder.rs:38:17
   4: regalloc2::cfg::CFGInfo::init
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/cfg.rs:53:9
   5: regalloc2::cfg::CFGInfo::new
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/cfg.rs:46:9
   6: regalloc2::fastalloc::run
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/fastalloc/mod.rs:1290:29
   7: regalloc2::run
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/lib.rs:1600:13
   8: regalloc_panic::main
             at ./grus_codegen/examples/regalloc_panic.rs:173:21
   9: core::ops::function::FnOnce::call_once
             at /home/ivor/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
```


```
thread 'main' panicked at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/ssa.rs:19:26:
index out of bounds: the len is 4 but the index is 6
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_bounds_check
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:273:5
   3: <usize as core::slice::index::SliceIndex<[T]>>::index
             at /home/ivor/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:274:10
   4: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /home/ivor/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:16:9
   5: <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
             at /home/ivor/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3361:9
   6: regalloc2::ssa::validate_ssa::{{closure}}
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/ssa.rs:19:26
   7: regalloc2::ssa::validate_ssa
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/ssa.rs:33:21
   8: regalloc2::fastalloc::run
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/fastalloc/mod.rs:1290:9
   9: regalloc2::run
             at /home/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/regalloc2-0.11.1/src/lib.rs:1600:13
  10: regalloc_panic::main
             at ./grus_codegen/examples/regalloc_panic.rs:192:22
  11: core::ops::function::FnOnce::call_once
             at /home/ivor/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5

```

</details>

Commits are split out:
- c536d39210aced8de6d5bdf757f64191452fe3bb adds checks that mitigate the panics.
- a3f088231e7a0d4d859709d80c3588f3e7fbb45a adds documentation to the `RegAllocError` enum, and a note in `Function` that states the requirement on the indices.
- cf441a96feb03dd5ccd6b65b7df972669f085774 adds some drive-by fixes to the documentation, they gave warnings about `[alloc_s]` not being an existing token, and `Operand::fixed` not existing, I think that should be `OperandConstraint::FixedReg` now?, lastly `target/` in the `.gitignore` doesn't match a symlink (I always use one to a ramdisk).

With these changes, the mentioned minimal non working example runs cleanly en reports `Err` as a return from the `run` method for both allocators.