### PR TITLE
TooManyLiveRegs check: fix `break` that was broken by allocator change.

### DIFF
--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -1258,8 +1258,7 @@ impl<'a, F: Function> Env<'a, F> {
                                 continue;
                             }
                             if preg_range.from >= range.to {
-                                // Success, return scratch memory to context and finish
-                                break 'outer;
+                                break;
                             }
                             if lr.is_valid() {
                                 if self.minimal_bundle(self.ranges[*lr].bundle) {


### PR DESCRIPTION
In #196, various `break`s and early returns` out of a main allocator loop were changed to pass through a point that returned scratch storage to a context for later reuse.

Unfortunately, this refactor introduced a bug: a `break` became a `break 'outer`, and the latter meant that we were skipping some checks.

Fortunately this only happens in a code-path where the given allocation problem has too many constraints, and it means that we get a panic rather than a `TooManyLiveRegs` error cleanly returned, so this is not a security issue. However, it has me a little paranoid and we should carefully re-audit #196's changes when we get a chance.

(Discovered while making changes to ABI code that caused too many defs constrained to regs, resulting in an un-allocatable input; not reachable from mainline Cranelift.)

cc @jakubDoka 