### PR TITLE
Fuzzing: add "callsite-ish constraints".

### DIFF
--- a/fuzz/fuzz_targets/fastalloc_checker.rs
+++ b/fuzz/fuzz_targets/fastalloc_checker.rs
@@ -25,6 +25,7 @@ impl Arbitrary<'_> for TestCase {
                     fixed_nonallocatable: true,
                     clobbers: true,
                     reftypes: false,
+                    callsite_ish_constraints: true,
                 },
             )?,
         })

--- a/fuzz/fuzz_targets/ion_checker.rs
+++ b/fuzz/fuzz_targets/ion_checker.rs
@@ -25,6 +25,7 @@ impl Arbitrary<'_> for TestCase {
                     fixed_nonallocatable: true,
                     clobbers: true,
                     reftypes: true,
+                    callsite_ish_constraints: true,
                 },
             )?,
         })

--- a/fuzz/fuzz_targets/ssagen.rs
+++ b/fuzz/fuzz_targets/ssagen.rs
@@ -26,6 +26,7 @@ impl Arbitrary<'_> for TestCase {
                     fixed_nonallocatable: true,
                     clobbers: true,
                     reftypes: true,
+                    callsite_ish_constraints: true,
                 },
             )?,
         })


### PR DESCRIPTION
This is a followup from #214. We have use-cases in Cranelift now where we generate constraints on call instructions that have:

- A number of fixed-reg uses at "early";
- A number of fixed-reg defs at "late";
- A number of register clobbers, potentially overlapping with uses;
- A number of "any"-constrained defs at "late", to add register pressure.

The existing fuzzing function generator would create at most 3 operands, and would add *either* fixed-reg constraints *or* clobbers, not both.

This PR adds a "callsite-ish constraints" branch as a subcase of the fixed-reg choice that also adds the "any" defs to add register pressure, and adds new clobbers that don't interfere with existing constraints. It also loosens the logic around constructing fixed-reg constraints: if a conflict is found with some arbitrarily-chosen constraint, it keeps going to the next operand and tries to make it fixed, rather than giving up on further operands.