### PR TITLE
Release 0.12.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["regalloc2-tool"]
 
 [package]
 name = "regalloc2"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     "Chris Fallin <chris@cfallin.org>",
     "Mozilla SpiderMonkey Developers",


### PR DESCRIPTION
Includes #224 to fix a case where the checker had a false positive failure on branches with defs.