### PR TITLE
Handle up to 2^16 - 1 operands per inst, and error properly on more.

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -179,13 +179,13 @@ impl LiveRange {
 pub struct Use {
     pub operand: Operand,
     pub pos: ProgPoint,
-    pub slot: u8,
+    pub slot: u16,
     pub weight: u16,
 }
 
 impl Use {
     #[inline(always)]
-    pub fn new(operand: Operand, pos: ProgPoint, slot: u8) -> Self {
+    pub fn new(operand: Operand, pos: ProgPoint, slot: u16) -> Self {
         Self {
             operand,
             pos,
@@ -315,8 +315,8 @@ pub struct PRegData {
 #[derive(Clone, Debug)]
 pub struct MultiFixedRegFixup {
     pub pos: ProgPoint,
-    pub from_slot: u8,
-    pub to_slot: u8,
+    pub from_slot: u16,
+    pub to_slot: u16,
     pub level: FixedRegFixupLevel,
     pub to_preg: PRegIndex,
     pub vreg: VRegIndex,

--- a/src/ion/mod.rs
+++ b/src/ion/mod.rs
@@ -83,7 +83,7 @@ impl<'a, F: Function> Env<'a, F> {
     pub(crate) fn init(&mut self) -> Result<(), RegAllocError> {
         self.create_pregs_and_vregs();
         self.compute_liveness()?;
-        self.build_liveranges();
+        self.build_liveranges()?;
         self.fixup_multi_fixed_vregs();
         self.merge_vreg_bundles();
         self.queue_bundles();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1577,6 +1577,9 @@ pub enum RegAllocError {
     /// Too many pinned VRegs + Reg-constrained Operands are live at
     /// once, making allocation impossible.
     TooManyLiveRegs,
+    /// Too many operands on a single instruction (beyond limit of
+    /// 2^16 - 1).
+    TooManyOperands,
 }
 
 impl core::fmt::Display for RegAllocError {


### PR DESCRIPTION
This PR addresses an underlying limitation that became a problem for Cranelift recently, after folding return-value loads into call pseudoinsts (thus producing single instructions with many operands): we only supported 255 operands per instruction.

It appears that `Use` was using a `u8` for the "slot index" for an operand as a result of earlier optimization/packing efforts. However, the current shape of the struct leaves a padding byte free, so we should be able to expand to a `u16` with no loss in performance.

Furthermore, previously we weren't catching the overflow, but rather were silently wrapping around (eek). This properly returns a `RegAllocError::TooManyOperands` now if an instruction has too many operands (more than `u16::MAX`).