### PR TITLE
Re-add support for stack constraints.

### DIFF
--- a/doc/ION.md
+++ b/doc/ION.md
@@ -442,11 +442,14 @@ other):
 
 ```plain
 
-                         Any(rc)
-                        /       \
-              FixedReg(reg)   FixedStack(reg)
-                        \       /
-                         Conflict
+        ___Unknown_____
+        |      |      |
+        |      |      |
+        | ____Any(rc) |
+        |/     |      |
+   Stack(rc)  FixedReg(reg)
+         \    /
+        Conflict
 ```
 
 Once we have the Requirement for a bundle, we can decide what to do.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -640,6 +640,17 @@ impl CheckerState {
                 }
                 return Err(CheckerError::AllocationIsNotReg { inst, op, alloc });
             }
+            OperandConstraint::Stack => {
+                if alloc.kind() != AllocationKind::Stack {
+                    // Accept pregs that represent a fixed stack slot.
+                    if let Some(preg) = alloc.as_reg() {
+                        if checker.machine_env.fixed_stack_slots.contains(&preg) {
+                            return Ok(());
+                        }
+                    }
+                    return Err(CheckerError::AllocationIsNotStack { inst, op, alloc });
+                }
+            }
             OperandConstraint::FixedReg(preg) => {
                 if alloc != Allocation::reg(preg) {
                     return Err(CheckerError::AllocationIsNotFixedReg { inst, op, alloc });

--- a/src/fastalloc/mod.rs
+++ b/src/fastalloc/mod.rs
@@ -453,6 +453,10 @@ impl<'a, F: Function> Env<'a, F> {
             OperandConstraint::Reuse(_) => {
                 unreachable!()
             }
+
+            OperandConstraint::Stack => {
+                panic!("Stack constraints not supported in fastalloc");
+            }
         }
     }
 
@@ -575,6 +579,10 @@ impl<'a, F: Function> Env<'a, F> {
             OperandConstraint::Reuse(_) => {
                 // This is handled elsewhere.
                 unreachable!();
+            }
+
+            OperandConstraint::Stack => {
+                panic!("Stack operand constraints not supported in fastalloc");
             }
         };
         self.allocs[(inst.index(), op_idx)] = new_alloc;

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -242,6 +242,11 @@ impl LiveBundle {
     }
 
     #[inline(always)]
+    pub fn cached_stack(&self) -> bool {
+        self.spill_weight_and_props & (1 << 28) != 0
+    }
+
+    #[inline(always)]
     pub fn set_cached_fixed(&mut self) {
         self.spill_weight_and_props |= 1 << 30;
     }
@@ -252,8 +257,13 @@ impl LiveBundle {
     }
 
     #[inline(always)]
+    pub fn set_cached_stack(&mut self) {
+        self.spill_weight_and_props |= 1 << 28;
+    }
+
+    #[inline(always)]
     pub fn cached_spill_weight(&self) -> u32 {
-        self.spill_weight_and_props & BUNDLE_MAX_SPILL_WEIGHT
+        self.spill_weight_and_props & ((1 << 28) - 1)
     }
 }
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -265,7 +265,7 @@ impl LiveBundle {
 
     #[inline(always)]
     pub fn cached_spill_weight(&self) -> u32 {
-        self.spill_weight_and_props & ((1 << 28) - 1)
+        self.spill_weight_and_props & BUNDLE_MAX_SPILL_WEIGHT
     }
 }
 

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -205,7 +205,7 @@ pub struct LiveBundle {
     pub spill_weight_and_props: u32,
 }
 
-pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 29) - 1;
+pub const BUNDLE_MAX_SPILL_WEIGHT: u32 = (1 << 28) - 1;
 pub const MINIMAL_FIXED_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT;
 pub const MINIMAL_BUNDLE_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 1;
 pub const BUNDLE_MAX_NORMAL_SPILL_WEIGHT: u32 = BUNDLE_MAX_SPILL_WEIGHT - 2;
@@ -218,12 +218,14 @@ impl LiveBundle {
         minimal: bool,
         fixed: bool,
         fixed_def: bool,
+        stack: bool,
     ) {
         debug_assert!(spill_weight <= BUNDLE_MAX_SPILL_WEIGHT);
         self.spill_weight_and_props = spill_weight
             | (if minimal { 1 << 31 } else { 0 })
             | (if fixed { 1 << 30 } else { 0 })
-            | (if fixed_def { 1 << 29 } else { 0 });
+            | (if fixed_def { 1 << 29 } else { 0 })
+            | (if stack { 1 << 28 } else { 0 });
     }
 
     #[inline(always)]

--- a/src/ion/liveranges.rs
+++ b/src/ion/liveranges.rs
@@ -824,6 +824,10 @@ impl<'a, F: Function> Env<'a, F> {
                                     first_reg_slot.get_or_insert(u.slot);
                                 }
                             }
+                            // Maybe this could be supported in this future...
+                            OperandConstraint::Stack => panic!(
+                                "multiple uses of vreg with a Stack constraint are not supported"
+                            ),
                         }
                     }
 

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -112,7 +112,11 @@ impl<'a, F: Function> Env<'a, F> {
         }
 
         // Check for a requirements conflict.
-        if self.bundles[from].cached_fixed() || self.bundles[to].cached_fixed() {
+        if self.bundles[from].cached_stack()
+            || self.bundles[from].cached_fixed()
+            || self.bundles[to].cached_stack()
+            || self.bundles[to].cached_fixed()
+        {
             if self.merge_bundle_requirements(from, to).is_err() {
                 trace!(" -> conflicting requirements; aborting merge");
                 return false;
@@ -154,6 +158,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
             self.bundles[to].ranges = list;
 
+            if self.bundles[from].cached_stack() {
+                self.bundles[to].set_cached_stack();
+            }
             if self.bundles[from].cached_fixed() {
                 self.bundles[to].set_cached_fixed();
             }
@@ -236,6 +243,9 @@ impl<'a, F: Function> Env<'a, F> {
             *to_range = to_range.join(from_range);
         }
 
+        if self.bundles[from].cached_stack() {
+            self.bundles[to].set_cached_stack();
+        }
         if self.bundles[from].cached_fixed() {
             self.bundles[to].set_cached_fixed();
         }

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -282,6 +282,7 @@ impl<'a, F: Function> Env<'a, F> {
 
             let mut fixed = false;
             let mut fixed_def = false;
+            let mut stack = false;
             for entry in &self.bundles[bundle].ranges {
                 for u in &self.ranges[entry.index].uses {
                     if let OperandConstraint::FixedReg(_) = u.operand.constraint() {
@@ -290,7 +291,10 @@ impl<'a, F: Function> Env<'a, F> {
                             fixed_def = true;
                         }
                     }
-                    if fixed && fixed_def {
+                    if let OperandConstraint::Stack = u.operand.constraint() {
+                        stack = true;
+                    }
+                    if fixed && stack && fixed_def {
                         break;
                     }
                 }
@@ -300,6 +304,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
             if fixed_def {
                 self.bundles[bundle].set_cached_fixed_def();
+            }
+            if stack {
+                self.bundles[bundle].set_cached_stack();
             }
 
             // Create a spillslot for this bundle.

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -1046,7 +1046,8 @@ impl<'a, F: Function> Env<'a, F> {
                 Requirement::Stack => {
                     // If we must be on the stack, mark our spillset
                     // as required immediately.
-                    self.spillsets[self.bundles[bundle].spillset].required = true;
+                    let spillset = self.bundles[bundle].spillset;
+                    self.spillsets[spillset].required = true;
                     return Ok(());
                 }
 

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -267,6 +267,7 @@ impl<'a, F: Function> Env<'a, F> {
         let minimal;
         let mut fixed = false;
         let mut fixed_def = false;
+        let mut stack = false;
         let bundledata = &self.ctx.bundles[bundle];
         let num_ranges = bundledata.ranges.len();
         let first_range = bundledata.ranges[0].index;
@@ -288,7 +289,12 @@ impl<'a, F: Function> Env<'a, F> {
                         trace!("  -> is fixed def");
                         fixed_def = true;
                     }
-
+                }
+                if let OperandConstraint::Stack = u.operand.constraint() {
+                    trace!("  -> stack operand at {:?}: {:?}", u.pos, u.operand);
+                    stack = true;
+                }
+                if stack && fixed {
                     break;
                 }
             }
@@ -351,6 +357,7 @@ impl<'a, F: Function> Env<'a, F> {
             minimal,
             fixed,
             fixed_def,
+            stack,
         );
     }
 
@@ -1036,6 +1043,12 @@ impl<'a, F: Function> Env<'a, F> {
             let fixed_preg = match req {
                 Requirement::FixedReg(preg) | Requirement::FixedStack(preg) => Some(preg),
                 Requirement::Register => None,
+                Requirement::Stack => {
+                    // If we must be on the stack, mark our spillset
+                    // as required immediately.
+                    self.spillsets[self.bundles[bundle].spillset].required = true;
+                    return Ok(());
+                }
 
                 Requirement::Any => {
                     self.ctx.spilled_bundles.push(bundle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,8 @@ pub enum OperandConstraint {
     Any,
     /// Operand must be in a register. Register is read-only for Uses.
     Reg,
+    /// Operand must be on the stack.
+    Stack,
     /// Operand must be in a fixed register.
     FixedReg(PReg),
     /// On defs only: reuse a use's register.
@@ -539,6 +541,7 @@ impl core::fmt::Display for OperandConstraint {
         match self {
             Self::Any => write!(f, "any"),
             Self::Reg => write!(f, "reg"),
+            Self::Stack => write!(f, "stack"),
             Self::FixedReg(preg) => write!(f, "fixed({})", preg),
             Self::Reuse(idx) => write!(f, "reuse({})", idx),
         }
@@ -634,6 +637,7 @@ impl Operand {
         let constraint_field = match constraint {
             OperandConstraint::Any => 0,
             OperandConstraint::Reg => 1,
+            OperandConstraint::Stack => 2,
             OperandConstraint::FixedReg(preg) => {
                 debug_assert_eq!(preg.class(), vreg.class());
                 0b1000000 | preg.hw_enc() as u32
@@ -906,6 +910,7 @@ impl Operand {
             match constraint_field {
                 0 => OperandConstraint::Any,
                 1 => OperandConstraint::Reg,
+                2 => OperandConstraint::Stack,
                 _ => unreachable!(),
             }
         }


### PR DESCRIPTION
In bytecodealliance/wasmtime#11285, we are discussing various approaches to allow generated code to communicate some "dynamic context" from exception-handling callsites to a stack-walker, without requiring changes to the overall frame format. The approach that seems to be the best choice so far is to add a stack-constrained vreg use to a try-call instruction and then communicate its location on the stack to the stack-walker in the exception metadata. The upshot of this is that we need support for stack-constrained operands.

Unfortunately we removed this support in #185 because we had removed the last (at the time) use-case for it, namely, GC stackmaps. Fortunately, reverting that PR (and most of a subsequent one, #192, that fixed up the removal), seems to be fairly straightforward. Those two reverts plus a few small fixups are included in this PR. It seems to fuzz cleanly when fuzzed briefly; I will fuzz it overnight and also make use of it in above-mentioned use-case to ensure it works properly.