### PR TITLE
Arbitrary Any Defs and Stack-Only Constraints for Fastalloc

### DIFF
--- a/src/fastalloc/iter.rs
+++ b/src/fastalloc/iter.rs
@@ -33,6 +33,10 @@ impl<'a> Operands<'a> {
     pub fn fixed(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
         self.matches(|op| matches!(op.constraint(), OperandConstraint::FixedReg(_)))
     }
+
+    pub fn any_reg(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
+        self.matches(|op| matches!(op.constraint(), OperandConstraint::Reg))
+    }
 }
 
 impl<'a> core::ops::Index<usize> for Operands<'a> {

--- a/src/fastalloc/mod.rs
+++ b/src/fastalloc/mod.rs
@@ -508,9 +508,7 @@ impl<'a, F: Function> Env<'a, F> {
                 unreachable!()
             }
 
-            OperandConstraint::Stack => {
-                panic!("Stack constraints not supported in fastalloc");
-            }
+            OperandConstraint::Stack => self.edits.is_stack(alloc),
         }
     }
 
@@ -668,9 +666,7 @@ impl<'a, F: Function> Env<'a, F> {
                 unreachable!();
             }
 
-            OperandConstraint::Stack => {
-                panic!("Stack operand constraints not supported in fastalloc");
-            }
+            OperandConstraint::Stack => Allocation::stack(self.get_spillslot(op.vreg())),
         };
         self.allocs[(inst.index(), op_idx)] = new_alloc;
         Ok(new_alloc)

--- a/src/fastalloc/vregset.rs
+++ b/src/fastalloc/vregset.rs
@@ -58,7 +58,7 @@ impl VRegSet {
         self.items[self.head.index()].next == self.head
     }
 
-    pub fn iter(&self) -> VRegSetIter {
+    pub fn iter(&self) -> VRegSetIter<'_> {
         VRegSetIter {
             curr_item: self.items[self.head.index()].next,
             head: self.head,


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/regalloc2/issues/217.

- Adds support for an arbitrary number of Any def operands
- Adds support for stack-only operands

Benchmarking this branch against the implementation on the main branch with sightglass, most benchmarks have no significant difference while a few others have a speed difference of about 1-1.83x, with the main branch being faster on some and this branch being faster on others.
