### PR TITLE
Fastalloc Def branch arg on branch & Bug Fixes

### DIFF
--- a/src/fastalloc/iter.rs
+++ b/src/fastalloc/iter.rs
@@ -1,4 +1,4 @@
-use crate::{Operand, OperandConstraint, OperandKind};
+use crate::{Operand, OperandConstraint, OperandKind, OperandPos};
 
 pub struct Operands<'a>(pub &'a [Operand]);
 
@@ -36,6 +36,14 @@ impl<'a> Operands<'a> {
 
     pub fn any_reg(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
         self.matches(|op| matches!(op.constraint(), OperandConstraint::Reg))
+    }
+    
+    pub fn late(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
+        self.matches(|op| op.pos() == OperandPos::Late)
+    }
+
+    pub fn early(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
+        self.matches(|op| op.pos() == OperandPos::Early)
     }
 }
 

--- a/src/fastalloc/iter.rs
+++ b/src/fastalloc/iter.rs
@@ -37,7 +37,7 @@ impl<'a> Operands<'a> {
     pub fn any_reg(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
         self.matches(|op| matches!(op.constraint(), OperandConstraint::Reg))
     }
-    
+
     pub fn late(&self) -> impl Iterator<Item = (usize, Operand)> + 'a {
         self.matches(|op| op.pos() == OperandPos::Late)
     }

--- a/src/fastalloc/lru.rs
+++ b/src/fastalloc/lru.rs
@@ -272,6 +272,8 @@ pub struct PartedByRegClass<T> {
     pub items: [T; 3],
 }
 
+impl<T: Copy> Copy for PartedByRegClass<T> {}
+
 impl<T> Index<RegClass> for PartedByRegClass<T> {
     type Output = T;
 
@@ -283,6 +285,12 @@ impl<T> Index<RegClass> for PartedByRegClass<T> {
 impl<T> IndexMut<RegClass> for PartedByRegClass<T> {
     fn index_mut(&mut self, index: RegClass) -> &mut Self::Output {
         &mut self.items[index as usize]
+    }
+}
+
+impl<T: PartialEq> PartialEq for PartedByRegClass<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.items.eq(&other.items)
     }
 }
 

--- a/src/fastalloc/mod.rs
+++ b/src/fastalloc/mod.rs
@@ -583,8 +583,8 @@ impl<'a, F: Function> Env<'a, F> {
                         self.vreg_in_preg[preg.index()] == op.vreg() &&
                             // If it's a late operand, it shouldn't be allocated to a
                             // clobber. For example:
-                            // use v0 (fixed: p0), late use v1
-                            // If p0 is a clobber, then v1 shouldn't be allocated to it.
+                            // use v0 (fixed: p0), late use v0
+                            // If p0 is a clobber, then v0 shouldn't be allocated to it.
                             (op.pos() != OperandPos::Late || !self.func.inst_clobbers(inst).contains(preg))
                     } else {
                         true

--- a/src/fastalloc/mod.rs
+++ b/src/fastalloc/mod.rs
@@ -1023,7 +1023,14 @@ impl<'a, F: Function> Env<'a, F> {
         Ok(())
     }
 
-    fn alloc_def_op(&mut self, op_idx: usize, op: Operand, operands: &[Operand], block: Block, inst: Inst) -> Result<(), RegAllocError> {
+    fn alloc_def_op(
+        &mut self,
+        op_idx: usize,
+        op: Operand,
+        operands: &[Operand],
+        block: Block,
+        inst: Inst,
+    ) -> Result<(), RegAllocError> {
         trace!("Allocating def operand {op}");
         if let OperandConstraint::Reuse(reused_idx) = op.constraint() {
             let reused_op = operands[reused_idx];
@@ -1040,8 +1047,7 @@ impl<'a, F: Function> Env<'a, F> {
             // If the defined vreg is used as a branch arg and it has an
             // any or stack constraint, define it into the block param spillslot
             let mut param_spillslot = None;
-            'outer: for (succ_idx, succ) in
-                self.func.block_succs(block).iter().cloned().enumerate()
+            'outer: for (succ_idx, succ) in self.func.block_succs(block).iter().cloned().enumerate()
             {
                 for (param_idx, branch_arg_vreg) in self
                     .func
@@ -1087,7 +1093,7 @@ impl<'a, F: Function> Env<'a, F> {
         self.freealloc(op.vreg());
         Ok(())
     }
-    
+
     fn alloc_use(&mut self, op_idx: usize, op: Operand, inst: Inst) -> Result<(), RegAllocError> {
         trace!("Allocating use op {op}");
         if self.reused_input_to_reuse_op[op_idx] != usize::MAX {
@@ -1106,7 +1112,7 @@ impl<'a, F: Function> Env<'a, F> {
         }
         Ok(())
     }
-    
+
     fn alloc_inst(&mut self, block: Block, inst: Inst) -> Result<(), RegAllocError> {
         trace!("Allocating instruction {:?}", inst);
         self.reset_available_pregs_and_scratch_regs();
@@ -1196,8 +1202,12 @@ impl<'a, F: Function> Env<'a, F> {
                     trace!("Decrementing clobber avail preg");
                     self.num_available_pregs[ExclusiveOperandPos::LateOnly][preg.class()] -= 1;
                     self.num_available_pregs[ExclusiveOperandPos::Both][preg.class()] -= 1;
-                    debug_assert!(self.num_available_pregs[ExclusiveOperandPos::LateOnly][preg.class()] >= 0);
-                    debug_assert!(self.num_available_pregs[ExclusiveOperandPos::Both][preg.class()] >= 0);
+                    debug_assert!(
+                        self.num_available_pregs[ExclusiveOperandPos::LateOnly][preg.class()] >= 0
+                    );
+                    debug_assert!(
+                        self.num_available_pregs[ExclusiveOperandPos::Both][preg.class()] >= 0
+                    );
                 } else {
                     // Some fixed-reg operands may be clobbers and so the decrement
                     // of the num avail regs has already been done.
@@ -1222,8 +1232,14 @@ impl<'a, F: Function> Env<'a, F> {
             "Number of available pregs for int, float, vector any-reg and any ops: {:?}",
             self.num_available_pregs
         );
-        trace!("registers available for early reg-only & any operands: {}", self.available_pregs[OperandPos::Early]);
-        trace!("registers available for late reg-only & any operands: {}", self.available_pregs[OperandPos::Late]);
+        trace!(
+            "registers available for early reg-only & any operands: {}",
+            self.available_pregs[OperandPos::Early]
+        );
+        trace!(
+            "registers available for late reg-only & any operands: {}",
+            self.available_pregs[OperandPos::Late]
+        );
 
         for (op_idx, op) in operands.late() {
             if op.kind() == OperandKind::Def {


### PR DESCRIPTION
Resolves https://github.com/bytecodealliance/wasmtime/issues/11545 and https://github.com/bytecodealliance/wasmtime/issues/11544.


- Add support for any, fixed-reg and stack-only branch arguments being defined in its branch instruction.
- Remove over-constraint on reservation of registers for operands with any-reg constraints. Instead, use counters to decide when it is safe to allocate registers to operands with no constraints.
- Correct `allocd_within_constraint` to account for allocation of clobbers to late phase registers.
- Correct `select_suitable_reg_in_lru` to only allocate available pregs in both late and early phases to early defs and late uses.
- Allocate late operands first, followed by early operands, instead of defs then uses.
- Remove over-constraint on available registers by removing clobbers only from the late available register set.

Previously, operands with any-reg constraints all got their registers reserved as if they were all late uses so as to avoid a situation where a register meant for an operand valid for both early and late phases is allocated to an operand valid only in an early phase or a late phase, but not both, potentially leaving no valid registers for an early & late phase operand.
This is an over-constraint that led to this issue https://github.com/bytecodealliance/wasmtime/issues/11544.
This is resolved by completely ditching the reservation of any-reg operands in favor of using counters to determine whether or not it is safe to allocate registers to operands with no constraints.

Another issue:
```
use v0 fixed(p0), def v1 fixed(p0), use late v0 any
```
In this scenario, p0 is fixed to both v1 and v0, but that shouldn't be a problem because they are in different phases. Prior to this PR, this was problematic because all defs were allocated first, then uses resulting in an allocation order in the above example that looked like this:
```
p0 -> v1 (this is a def, so it's freed and vreg_allocs[v1] is set to none)
p0 -> v0 (vreg_allocs[v0] = p0)
p0 -> v0 (vreg_allocs[v0] is p0, which is within constraints, so it is selected)
```
Which is incorrect. The root cause is that during allocation, vreg_allocs[vi] tells the current allocation of some register vi - but when the late v0 operand is being allocated, vreg_allocs[vi] tells the allocation of v0 in the early phase of the instruction, not the late phase, and since allocation proceeds in reverse, this is an incorrect order. It should always proceed from the late phase to the early phase. To resolve this, instead of all def operands being allocated first, then use operands, it's the late operands that are allocated first, followed by the early operands. This is still safe because the reason def operands were allocated first is because registers allocated to late def operands can be reused by early use operands, and in this processing order, this order will still remain this same.

Fuzzed overnight for 8-9 hours.
I also ran Wasmtime's tests. Most pass. The ones that didn't pass didn't seem to fail because of register allocation - for example, the disas test checks against hardcoded output.