### PR TITLE
Pass hints to `RegTraversalIter` as `Option<PReg>`

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -295,7 +295,7 @@ const fn no_bloat_capacity<T>() -> usize {
 #[derive(Clone, Debug)]
 pub struct SpillSet {
     pub slot: SpillSlotIndex,
-    pub reg_hint: PReg,
+    pub hint: PReg,
     pub class: RegClass,
     pub spill_bundle: LiveBundleIndex,
     pub required: bool,
@@ -594,7 +594,7 @@ pub struct PrioQueue {
 pub struct PrioQueueEntry {
     pub prio: u32,
     pub bundle: LiveBundleIndex,
-    pub reg_hint: PReg,
+    pub hint: PReg,
 }
 
 #[derive(Clone, Debug)]
@@ -664,11 +664,11 @@ impl<'a> ContainerComparator for PrioQueueComparator<'a> {
 
 impl PrioQueue {
     #[inline(always)]
-    pub fn insert(&mut self, bundle: LiveBundleIndex, prio: usize, reg_hint: PReg) {
+    pub fn insert(&mut self, bundle: LiveBundleIndex, prio: usize, hint: PReg) {
         self.heap.push(PrioQueueEntry {
             prio: prio as u32,
             bundle,
-            reg_hint,
+            hint,
         });
     }
 
@@ -679,7 +679,7 @@ impl PrioQueue {
 
     #[inline(always)]
     pub fn pop(&mut self) -> Option<(LiveBundleIndex, PReg)> {
-        self.heap.pop().map(|entry| (entry.bundle, entry.reg_hint))
+        self.heap.pop().map(|entry| (entry.bundle, entry.hint))
     }
 }
 

--- a/src/ion/merge.rs
+++ b/src/ion/merge.rs
@@ -315,7 +315,7 @@ impl<'a, F: Function> Env<'a, F> {
                 slot: SpillSlotIndex::invalid(),
                 required: false,
                 class: reg.class(),
-                reg_hint: PReg::invalid(),
+                hint: PReg::invalid(),
                 spill_bundle: LiveBundleIndex::invalid(),
                 splits: 0,
                 range,

--- a/src/ion/moves.rs
+++ b/src/ion/moves.rs
@@ -892,8 +892,7 @@ impl<'a, F: Function> Env<'a, F> {
                 }
 
                 let resolved = parallel_moves.resolve();
-                let mut scratch_iter =
-                    RegTraversalIter::new(self.env, regclass, None, PReg::invalid(), 0);
+                let mut scratch_iter = RegTraversalIter::new(self.env, regclass, None, None, 0);
                 let mut dedicated_scratch = self.env.scratch_by_class[regclass as usize];
                 let key = LiveRangeKey::from_range(&CodeRange {
                     from: pos_prio.pos,

--- a/src/ion/reg_traversal.rs
+++ b/src/ion/reg_traversal.rs
@@ -79,14 +79,11 @@ impl<'a> RegTraversalIter<'a> {
         env: &'a MachineEnv,
         class: RegClass,
         fixed: Option<PReg>,
-        hint: PReg,
+        hint: Option<PReg>,
         offset: usize,
     ) -> Self {
-        let hint = if hint != PReg::invalid() {
-            Some(hint)
-        } else {
-            None
-        };
+        debug_assert!(fixed != Some(PReg::invalid()));
+        debug_assert!(hint != Some(PReg::invalid()));
 
         let class = class as u8 as usize;
         let preferred = Cursor::new(&env.preferred_regs_by_class[class], offset);

--- a/src/ion/spill.rs
+++ b/src/ion/spill.rs
@@ -30,7 +30,9 @@ impl<'a, F: Function> Env<'a, F> {
             }
 
             let class = self.ctx.spillsets[self.ctx.bundles[bundle].spillset].class;
-            let hint = self.ctx.spillsets[self.ctx.bundles[bundle].spillset].reg_hint;
+            let hint = self.ctx.spillsets[self.ctx.bundles[bundle].spillset]
+                .hint
+                .as_valid();
 
             // This may be an empty-range bundle whose ranges are not
             // sorted; sort all range-lists again here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ impl PReg {
     pub const MAX_BITS: usize = 6;
     pub const MAX: usize = (1 << Self::MAX_BITS) - 1;
     pub const NUM_INDEX: usize = 1 << (Self::MAX_BITS + 2); // including RegClass bits
+    pub const INVALID: u8 = ((RegClass::Int as u8) << Self::MAX_BITS) | (Self::MAX as u8);
 
     /// Create a new PReg. The `hw_enc` range is 6 bits.
     #[inline(always)]
@@ -162,7 +163,19 @@ impl PReg {
     /// data structures.
     #[inline(always)]
     pub const fn invalid() -> Self {
-        PReg::new(Self::MAX, RegClass::Int)
+        PReg {
+            bits: Self::INVALID,
+        }
+    }
+
+    /// Return a valid [`PReg`] or [`None`] if it is invalid.
+    #[inline(always)]
+    pub const fn as_valid(self) -> Option<Self> {
+        if self.bits == Self::INVALID {
+            None
+        } else {
+            Some(self)
+        }
     }
 }
 


### PR DESCRIPTION
As noted in a [comment] to #235, passing an `Option<PReg>` _is_ a bit more clear API. To do this, this change adds `PReg::is_valid()` to do the conversion. This change (rather unnecessarily) also renames this variable to `hint` everywhere (previously: `hint`, `hint_reg`, `reg_hint`) and uses variables directly in several close-by `format!` strings.

This is a non-functional change.

[comment]: https://github.com/bytecodealliance/regalloc2/pull/235#pullrequestreview-3236527918