### PR TITLE
Improve the generation of fuzz functions

### DIFF
--- a/fuzz/fuzz_targets/fastalloc_checker.rs
+++ b/fuzz/fuzz_targets/fastalloc_checker.rs
@@ -26,6 +26,7 @@ impl Arbitrary<'_> for TestCase {
                     clobbers: true,
                     reftypes: false,
                     callsite_ish_constraints: true,
+                    ..Options::default()
                 },
             )?,
         })
@@ -37,8 +38,8 @@ fuzz_target!(|testcase: TestCase| {
     let _ = env_logger::try_init();
     log::trace!("func:\n{:?}", func);
     let env = regalloc2::fuzzing::func::machine_env();
-    let out =
-        regalloc2::fuzzing::fastalloc::run(&func, &env, true, false).expect("regalloc did not succeed");
+    let out = regalloc2::fuzzing::fastalloc::run(&func, &env, true, false)
+        .expect("regalloc did not succeed");
 
     let mut checker = Checker::new(&func, &env);
     checker.prepare(&out);

--- a/fuzz/fuzz_targets/ion_checker.rs
+++ b/fuzz/fuzz_targets/ion_checker.rs
@@ -26,6 +26,7 @@ impl Arbitrary<'_> for TestCase {
                     clobbers: true,
                     reftypes: true,
                     callsite_ish_constraints: true,
+                    ..Options::default()
                 },
             )?,
         })

--- a/fuzz/fuzz_targets/ssagen.rs
+++ b/fuzz/fuzz_targets/ssagen.rs
@@ -27,6 +27,7 @@ impl Arbitrary<'_> for TestCase {
                     clobbers: true,
                     reftypes: true,
                     callsite_ish_constraints: true,
+                    ..Options::default()
                 },
             )?,
         })

--- a/src/fuzzing/func.rs
+++ b/src/fuzzing/func.rs
@@ -343,18 +343,14 @@ impl Func {
             let succ = *u.choose(&in_blocks[..])?;
             builder.add_edge(Block::new(pred), Block::new(succ));
         }
-
         builder.compute_doms();
 
         for block in 0..num_blocks {
             builder.f.block_preds[block].clear();
-        }
-        for block in 0..num_blocks {
             for &succ in &builder.f.block_succs[block] {
                 builder.f.block_preds[succ.index()].push(Block::new(block));
             }
         }
-
         builder.compute_doms();
 
         let alloc_vreg = |builder: &mut FuncBuilder, u: &mut Unstructured| {


### PR DESCRIPTION
This is intended as a non-functional refactor (with one caveat below). The generation of functions is quite tricky: `regalloc2` must always generate test case functions that _are_ allocatable. But the complex logic of `Func::arbitrary_with_options` makes this more difficult than it already is. This change attempts to simplify, document, and allow users of the `Func::arbitrary_with_options` more control over the generated test cases.

The one caveat is the number of clobbers. Previously, we generated different amounts of clobbers if `opts.fixed_regs && opts.callsite_ish_constraints` and if `opts.clobbers`: `0..=10` versus `0..=5`. I suspect this is an oversight (?) so I just used the same `opts.num_clobbers_per_inst` in both cases. This does change the fuzzing DNA, invalidating the corpus, but this will happen soon anyways if we start fuzzing `OperandConstraint::Limit`.