### PR TITLE
perf: Replace HashSet with generational vec

### DIFF
--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -447,32 +447,27 @@ impl core::ops::IndexMut<VReg> for VRegs {
 /// A dedup set of `LiveBundleIndex` values that avoids hashing.
 ///
 /// Each bundle index is mapped to a slot in a dense array holding the
-/// generation at which it was last inserted. `clear` simply bumps the
-/// current generation (O(1) in the common case), and `insert` is a
-/// single bounds-checked compare-and-store. This is a drop-in
-/// replacement for the previous `FxHashSet<LiveBundleIndex>` that is
-/// much cheaper when a bundle conflicts with many others (e.g. a
-/// function with many locals).
+/// generation at which it was last inserted. `clear` bumps the current
+/// generation and `insert` updates the stamp for the given bundle and
+/// resizes the array if necessary.
+/// This is a drop-in replacement for the previous `FxHashSet<LiveBundleIndex>`
+/// that is much cheaper when a bundle conflicts with many others (e.g. for
+/// functions with many locals).
 #[derive(Clone, Debug, Default)]
 pub struct ConflictSet {
     // Generation at which each bundle was last inserted. The value `0`
     // means "never inserted"; `generation` is therefore always >= 1
     // after the first `clear`.
-    stamps: Vec<u32>,
-    generation: u32,
+    stamps: Vec<u64>,
+    generation: u64,
 }
 
 impl ConflictSet {
-    /// Empty the set. O(1) except on the rare generation wraparound.
+    /// Empty the set by bumping the generation.
+    /// Every value below the new generation is now stale.
     #[inline]
     pub fn clear(&mut self) {
-        self.generation = self.generation.wrapping_add(1);
-        if self.generation == 0 {
-            // Wrapped around; reset stamps so stale entries don't read
-            // as present, and skip the reserved `0` generation.
-            self.stamps.iter_mut().for_each(|s| *s = 0);
-            self.generation = 1;
-        }
+        self.generation += 1;
     }
 
     /// Insert `bundle`. Returns `true` if it was not already present.

--- a/src/ion/data_structures.rs
+++ b/src/ion/data_structures.rs
@@ -444,6 +444,53 @@ impl core::ops::IndexMut<VReg> for VRegs {
     }
 }
 
+/// A dedup set of `LiveBundleIndex` values that avoids hashing.
+///
+/// Each bundle index is mapped to a slot in a dense array holding the
+/// generation at which it was last inserted. `clear` simply bumps the
+/// current generation (O(1) in the common case), and `insert` is a
+/// single bounds-checked compare-and-store. This is a drop-in
+/// replacement for the previous `FxHashSet<LiveBundleIndex>` that is
+/// much cheaper when a bundle conflicts with many others (e.g. a
+/// function with many locals).
+#[derive(Clone, Debug, Default)]
+pub struct ConflictSet {
+    // Generation at which each bundle was last inserted. The value `0`
+    // means "never inserted"; `generation` is therefore always >= 1
+    // after the first `clear`.
+    stamps: Vec<u32>,
+    generation: u32,
+}
+
+impl ConflictSet {
+    /// Empty the set. O(1) except on the rare generation wraparound.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        if self.generation == 0 {
+            // Wrapped around; reset stamps so stale entries don't read
+            // as present, and skip the reserved `0` generation.
+            self.stamps.iter_mut().for_each(|s| *s = 0);
+            self.generation = 1;
+        }
+    }
+
+    /// Insert `bundle`. Returns `true` if it was not already present.
+    #[inline]
+    pub fn insert(&mut self, bundle: LiveBundleIndex) -> bool {
+        let idx = bundle.index();
+        if idx >= self.stamps.len() {
+            self.stamps.resize(idx + 1, 0);
+        }
+        if self.stamps[idx] == self.generation {
+            false
+        } else {
+            self.stamps[idx] = self.generation;
+            true
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct Ctx {
     pub(crate) cfginfo: CFGInfo,
@@ -484,9 +531,10 @@ pub struct Ctx {
     pub(crate) debug_annotations: FxHashMap<ProgPoint, Vec<String>>,
     pub(crate) annotations_enabled: bool,
 
-    // Cached allocation for `try_to_allocate_bundle_to_reg` to avoid allocating
-    // a new HashSet on every call.
-    pub(crate) conflict_set: FxHashSet<LiveBundleIndex>,
+    // Scratch dedup set for `try_to_allocate_bundle_to_reg`, reused
+    // across calls. Uses generation stamping to avoid hashing and to
+    // make clearing O(1).
+    pub(crate) conflict_set: ConflictSet,
 
     // Output:
     pub output: Output,

--- a/src/ion/process.rs
+++ b/src/ion/process.rs
@@ -94,6 +94,7 @@ impl<'a, F: Function> Env<'a, F> {
             self.ctx.pregs[reg.index()].allocations.btree
         );
         let mut first_conflict: Option<ProgPoint> = None;
+        let mut last_conflict_bundle: Option<LiveBundleIndex> = None;
 
         'ranges: for entry in bundle_ranges {
             trace!(" -> range LR {:?}: {:?}", entry.index, entry.range);
@@ -158,6 +159,12 @@ impl<'a, F: Function> Env<'a, F> {
                     // conflicts list.
                     let conflict_bundle = self.ctx.ranges[*preg_range].bundle;
                     trace!("   -> conflict bundle {:?}", conflict_bundle);
+                    // Adjacent preg ranges very often belong to the same
+                    // bundle; skip the dedup-set lookup on repeats.
+                    if last_conflict_bundle == Some(conflict_bundle) {
+                        continue 'alloc;
+                    }
+                    last_conflict_bundle = Some(conflict_bundle);
                     if self.ctx.conflict_set.insert(conflict_bundle) {
                         conflicts.push(conflict_bundle);
                         max_conflict_weight = core::cmp::max(


### PR DESCRIPTION
When compiling certain types of functions (e.g. with many locals), a lot of time is spent in `try_to_allocate_bundle_to_reg`, in particular on `HashSet::insert`. This data structure is only used for deduplicating and the cost can be quite high (hashing, allocations, bad cache properties).

Replacing it with a generational vector gives significant improvements for my ad-hoc benchmark (deliberately compiled with no optimizations, because my use-case currently demands it): 
Compiling a Wasm function with X locals before and after this patch: 
```
1000 locals: 780ms compilation -> 363ms   -53%
10k  locals:  66s compilation ->  23s     -65%
40k  locals: 952s compilation ->  356s    -62%
```
The Sightglass benchmarks are mixed, see the comment below. 

